### PR TITLE
fix(orchestration): fix checkpoint snapshot path namespace

### DIFF
--- a/MowisAI-main/agentd/src/orchestration/agent_execution.rs
+++ b/MowisAI-main/agentd/src/orchestration/agent_execution.rs
@@ -48,6 +48,16 @@ impl AgentExecutor {
         })
     }
 
+    /// Get the host path to the container's upper directory.
+    /// This is the actual path on the host filesystem, not the in-container path.
+    /// The agent's layer.upper_dir stores the in-container path (/sandbox/...),
+    /// but checkpoints run on the host where we need /tmp/container-{id}/upper.
+    fn get_host_upper_dir(&self, agent: &AgentHandle) -> PathBuf {
+        // Container ID is already the full ID (numeric with random bits)
+        // The host stores containers at /tmp/container-{container_id}/upper
+        PathBuf::from(format!("/tmp/container-{}/upper", agent.container_id))
+    }
+
     /// Execute task with agent
     pub async fn execute_task(
         &self,
@@ -101,15 +111,12 @@ impl AgentExecutor {
 
                     // Tier 2: Restore from last checkpoint
                     if let Some(last_checkpoint) = checkpoint_log.latest() {
-                        let upper_dir_str = format!(
-                            "/sandbox/{}/container/{}/upper",
-                            agent.sandbox_name, agent.container_id
-                        );
-                        let upper_dir = Path::new(&upper_dir_str);
+                        // Use host path, not in-container path
+                        let upper_dir = self.get_host_upper_dir(agent);
                         let snapshot_path = PathBuf::from(&last_checkpoint.layer_snapshot_path);
 
                         if snapshot_path.exists() {
-                            match self.checkpoint_manager.restore_snapshot(upper_dir, &snapshot_path) {
+                            match self.checkpoint_manager.restore_snapshot(&upper_dir, &snapshot_path) {
                                 Ok(()) => {
                                     log::info!("  ✓ Restored checkpoint {} for agent {}",
                                         last_checkpoint.id, &agent.agent_id[..8]);
@@ -306,11 +313,12 @@ impl AgentExecutor {
         // Create checkpoint after successful tool call
         let checkpoint_id = checkpoint_log.checkpoints.len() as u64;
 
-        // Create actual snapshot of agent's upper layer
+        // Create actual snapshot of agent's upper layer (using host path)
+        let upper_dir = self.get_host_upper_dir(agent);
         let snapshot_path = self.checkpoint_manager.create_snapshot(
             &agent.agent_id,
             checkpoint_id,
-            &Path::new(&format!("/sandbox/{}/container/{}/upper", agent.sandbox_name, agent.container_id)),
+            &upper_dir,
         )?;
 
         let checkpoint = Checkpoint {


### PR DESCRIPTION
This PR fixes the checkpoint snapshot failure caused by a path namespace mismatch. The checkpoint code was using in-container overlayfs paths (`/sandbox/...`) when executing `cp` commands on the host. Changed to use the actual host path (`/tmp/container-{id}/upper`) for both snapshot creation and restoration.

### Changes
- `agentd/src/orchestration/agent_execution.rs`: Added `get_host_upper_dir` helper to return host path for container upper directory; updated snapshot creation and restoration to use host paths instead of in-container paths.

<a href="https://capy.ai/project/7d64afda-66a2-47e2-9c9b-8cc3bedb4682/pull/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7d64afda-66a2-47e2-9c9b-8cc3bedb4682/task/61fe636d-ee3c-4eeb-acf1-f78baf0b3233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=auto&task=SCO-1&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=auto&task=SCO-1"><img alt="SCO-1 · Auto" src="https://capy.ai/api/badge/task.svg?model=auto&task=SCO-1"></picture></a>