### PR TITLE
Capy/fix checkpoint permissions

### DIFF
--- a/MowisAI-main/agentd/src/orchestration/agent_execution.rs
+++ b/MowisAI-main/agentd/src/orchestration/agent_execution.rs
@@ -48,6 +48,16 @@ impl AgentExecutor {
         })
     }
 
+    /// Get the host path to the container's upper directory.
+    /// This is the actual path on the host filesystem, not the in-container path.
+    /// The agent's layer.upper_dir stores the in-container path (/sandbox/...),
+    /// but checkpoints run on the host where we need /tmp/container-{id}/upper.
+    fn get_host_upper_dir(&self, agent: &AgentHandle) -> PathBuf {
+        // Container ID is already the full ID (numeric with random bits)
+        // The host stores containers at /tmp/container-{container_id}/upper
+        PathBuf::from(format!("/tmp/container-{}/upper", agent.container_id))
+    }
+
     /// Execute task with agent
     pub async fn execute_task(
         &self,
@@ -101,15 +111,12 @@ impl AgentExecutor {
 
                     // Tier 2: Restore from last checkpoint
                     if let Some(last_checkpoint) = checkpoint_log.latest() {
-                        let upper_dir_str = format!(
-                            "/sandbox/{}/container/{}/upper",
-                            agent.sandbox_name, agent.container_id
-                        );
-                        let upper_dir = Path::new(&upper_dir_str);
+                        // Use host path, not in-container path
+                        let upper_dir = self.get_host_upper_dir(agent);
                         let snapshot_path = PathBuf::from(&last_checkpoint.layer_snapshot_path);
 
                         if snapshot_path.exists() {
-                            match self.checkpoint_manager.restore_snapshot(upper_dir, &snapshot_path) {
+                            match self.checkpoint_manager.restore_snapshot(&upper_dir, &snapshot_path) {
                                 Ok(()) => {
                                     log::info!("  ✓ Restored checkpoint {} for agent {}",
                                         last_checkpoint.id, &agent.agent_id[..8]);
@@ -306,11 +313,12 @@ impl AgentExecutor {
         // Create checkpoint after successful tool call
         let checkpoint_id = checkpoint_log.checkpoints.len() as u64;
 
-        // Create actual snapshot of agent's upper layer
+        // Create actual snapshot of agent's upper layer (using host path)
+        let upper_dir = self.get_host_upper_dir(agent);
         let snapshot_path = self.checkpoint_manager.create_snapshot(
             &agent.agent_id,
             checkpoint_id,
-            &Path::new(&format!("/sandbox/{}/container/{}/upper", agent.sandbox_name, agent.container_id)),
+            &upper_dir,
         )?;
 
         let checkpoint = Checkpoint {

--- a/MowisAI-main/agentd/src/sandbox.rs
+++ b/MowisAI-main/agentd/src/sandbox.rs
@@ -15,6 +15,7 @@ use nix::mount::{mount, umount2, MntFlags, MsFlags};
 use nix::sched;
 use nix::sys::resource::{setrlimit, Resource};
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -626,6 +627,18 @@ impl Sandbox {
         fs::create_dir_all(&upper)?;
         fs::create_dir_all(&work)?;
         fs::create_dir_all(&root)?;
+
+        // Make container directories readable by all users so orchestration can checkpoint
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o755);
+            let _ = std::fs::set_permissions(&upper, perms.clone());
+            let _ = std::fs::set_permissions(&work, perms.clone());
+            let _ = std::fs::set_permissions(&root, perms);
+            // Also set permissions on the base directory itself
+            let _ = std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o755));
+        }
 
         // build the filesystem for the new container. when the sandbox was
         // created with an image we mount an overlay using that image as the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container filesystem path handling in checkpoint operations for better reliability
  * Enhanced container initialization by configuring Unix filesystem permissions on container directories for proper access controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->