### PR TITLE
fix(tui): enable dev log forwarding and event loop draining

### DIFF
--- a/agentd/src/tui/app.rs
+++ b/agentd/src/tui/app.rs
@@ -775,11 +775,9 @@ impl App {
     }
 
     pub fn on_log_entry(&mut self, level: String, message: String, timestamp: u64) {
-        if self.dev_mode_active {
-            self.dev_log.push((level, message, timestamp));
-            if self.dev_log.len() > 1000 {
-                self.dev_log.remove(0);
-            }
+        self.dev_log.push((level, message, timestamp));
+        if self.dev_log.len() > 1000 {
+            self.dev_log.remove(0);
         }
     }
 }

--- a/agentd/src/tui/mod.rs
+++ b/agentd/src/tui/mod.rs
@@ -18,6 +18,7 @@ use self::event::{spawn_event_thread, TuiEvent};
 /// Main entry point: interactive Claude Code-style TUI
 pub fn run_interactive(config: MowisConfig, socket_pid: Option<u32>) -> Result<()> {
     enable_raw_mode()?;
+    crate::logging::set_tui_active(true);
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
@@ -32,6 +33,7 @@ pub fn run_interactive(config: MowisConfig, socket_pid: Option<u32>) -> Result<(
 
     let result = run_loop(&mut terminal, config, socket_pid);
 
+    crate::logging::set_tui_active(false);
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
@@ -74,18 +76,21 @@ fn run_loop<B: ratatui::backend::Backend>(
     loop {
         terminal.draw(|f| ui::draw(f, &mut app))?;
 
-        match ui_rx.try_recv() {
-            Ok(TuiEvent::Key(key)) => app.handle_key(key),
-            Ok(TuiEvent::Tick) => app.on_tick(),
-            Ok(TuiEvent::GeminiChunk(text)) => app.on_gemini_chunk(text),
-            Ok(TuiEvent::GeminiDone) => app.on_gemini_done(),
-            Ok(TuiEvent::GeminiError(err)) => app.on_gemini_error(err),
-            Ok(TuiEvent::OrchEvent(ev)) => app.on_orch_event(ev),
-            Ok(TuiEvent::OrchDone) => app.on_orch_done(),
-            Ok(TuiEvent::LogEntry { level, message, timestamp }) => {
-                app.on_log_entry(level, message, timestamp);
+        // Drain all pending events before the next draw so log bursts don't lag behind.
+        loop {
+            match ui_rx.try_recv() {
+                Ok(TuiEvent::Key(key)) => app.handle_key(key),
+                Ok(TuiEvent::Tick) => app.on_tick(),
+                Ok(TuiEvent::GeminiChunk(text)) => app.on_gemini_chunk(text),
+                Ok(TuiEvent::GeminiDone) => app.on_gemini_done(),
+                Ok(TuiEvent::GeminiError(err)) => app.on_gemini_error(err),
+                Ok(TuiEvent::OrchEvent(ev)) => app.on_orch_event(ev),
+                Ok(TuiEvent::OrchDone) => app.on_orch_done(),
+                Ok(TuiEvent::LogEntry { level, message, timestamp }) => {
+                    app.on_log_entry(level, message, timestamp);
+                }
+                _ => break,
             }
-            _ => {}
         }
 
         if app.should_quit {


### PR DESCRIPTION
This PR fixes three issues preventing the `/development` log view from receiving and displaying log events: missing `set_tui_active` calls, conditional buffering that discarded logs before dev mode was toggled on, and single-event-per-frame processing causing log bursts to lag behind redraws.

**TUI Logging Integration**
* Added `crate::logging::set_tui_active(true)` in `tui/mod.rs` after `enable_raw_mode()` succeeds (line 21)
* Added `crate::logging::set_tui_active(false)` before TUI cleanup (line 36) to restore stderr mirroring on exit

**Log Event Loop**
* Replaced single `try_recv()` in `tui/mod.rs` with drain loop (lines 80-94) to process all pending events per frame

**Log Buffering**
* Removed `if self.dev_mode_active` guard from `on_log_entry()` in `tui/app.rs` (lines 777-784)
* Logs now always buffer into `dev_log` regardless of view toggle state, so toggling `/development` shows history

<a href="https://capy.ai/project/7d64afda-66a2-47e2-9c9b-8cc3bedb4682/pull/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/7d64afda-66a2-47e2-9c9b-8cc3bedb4682/task/c8264322-fae6-4c35-af55-ae8f23af0970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-6&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-6"><img alt="SCO-6 · Sonnet 4.6" src="https://capy.ai/api/badge/task.svg?model=claude-sonnet-4-6&task=SCO-6"></picture></a>