### PR TITLE
claude/debug-layer-6-orchestration-Ys3RJ

### DIFF
--- a/agentd/src/orchestration/mod.rs
+++ b/agentd/src/orchestration/mod.rs
@@ -110,17 +110,37 @@ pub(crate) fn gcloud_access_token() -> anyhow::Result<String> {
     let out = Command::new("gcloud")
         .args(["auth", "print-access-token"])
         .output()
-        .context("spawn gcloud — is it installed and on PATH?")?;
+        .context("spawn gcloud — is it installed and on PATH? Install with: gcloud auth application-default login")?;
     if !out.status.success() {
-        return Err(anyhow!(
-            "gcloud auth print-access-token failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        ));
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let msg = if stderr.contains("Application Default Credentials") {
+            format!(
+                "gcloud authentication not configured. Error: {}\n\
+                 Fix: Run 'gcloud auth application-default login' or set GOOGLE_APPLICATION_CREDENTIALS",
+                stderr
+            )
+        } else if stderr.contains("permission denied") || stderr.contains("not found") {
+            format!(
+                "gcloud command not found or not executable. Error: {}",
+                stderr
+            )
+        } else {
+            format!(
+                "gcloud auth failed: {}\n\
+                 Ensure you have: 1) gcloud installed, 2) logged in with 'gcloud auth login', \
+                 3) application default credentials with 'gcloud auth application-default login'",
+                stderr
+            )
+        };
+        return Err(anyhow!(msg));
     }
     let s = String::from_utf8(out.stdout).context("token utf-8")?;
     let t = s.trim().to_string();
     if t.is_empty() {
-        return Err(anyhow!("empty access token from gcloud"));
+        return Err(anyhow!(
+            "empty access token from gcloud. This usually means authentication failed. \
+             Try: gcloud auth application-default login"
+        ));
     }
     trace(&format!(
         "gcloud auth print-access-token: OAuth access token length={} chars (not Gemini output)",

--- a/agentd/src/orchestration/new_orchestrator.rs
+++ b/agentd/src/orchestration/new_orchestrator.rs
@@ -511,68 +511,122 @@ impl NewOrchestrator {
         send_event(OrchestratorEvent::LayerProgress { layer: 6, message: "Verifying sandbox results...".into() });
         log::info!("Layer 6: Verifying sandbox results...");
 
-        let verification_loop = VerificationLoop::new(
-            self.config.project_id.clone(),
-            self.config.max_verification_rounds,
-        );
-
         let mut verification_status = HashMap::new();
-        let known_issues = Vec::new();
+        let mut known_issues = Vec::new();
 
-        for (sandbox_name, sandbox_result) in &mut sandbox_results {
-            if let Some(ref diff) = sandbox_result.merged_diff.clone() {
-                if !diff.is_empty() {
-                    let original_tasks: Vec<agentd_protocol::Task> = planner_output
-                        .task_graph
-                        .tasks
-                        .iter()
-                        .filter(|t| {
-                            planner_output
-                                .sandbox_hints
-                                .get(&t.id)
-                                .map_or(false, |s| s == sandbox_name)
-                        })
-                        .cloned()
-                        .collect();
+        // Pre-verification check: ensure gcloud auth works before attempting any test execution
+        if let Err(gcloud_err) = super::gcloud_access_token() {
+            let error_msg = format!(
+                "⚠ Verification pre-flight check failed — gcloud authentication unavailable: {}. \
+                 Skipping all verification. To fix: {}",
+                gcloud_err,
+                if gcloud_err.to_string().contains("not found") || gcloud_err.to_string().contains("PATH") {
+                    "install gcloud CLI and ensure it's on your PATH"
+                } else if gcloud_err.to_string().contains("Application Default Credentials") {
+                    "run 'gcloud auth application-default login' or set GOOGLE_APPLICATION_CREDENTIALS environment variable"
+                } else {
+                    "see gcloud error above"
+                }
+            );
+            send_event(OrchestratorEvent::LayerProgress {
+                layer: 6,
+                message: error_msg.clone(),
+            });
+            log::warn!("{}", error_msg);
+            known_issues.push(format!("Verification skipped: {}", gcloud_err));
+            // Continue orchestration but mark all sandboxes as not verified
+            let sandbox_names: Vec<_> = sandbox_results.keys().cloned().collect();
+            for sandbox_name in sandbox_names {
+                if let Some(result) = sandbox_results.get_mut(&sandbox_name) {
+                    result.verification_status = VerificationStatus::NotStarted;
+                }
+                verification_status.insert(sandbox_name, VerificationStatus::NotStarted);
+            }
+        } else {
+            let verification_loop = VerificationLoop::new(
+                self.config.project_id.clone(),
+                self.config.max_verification_rounds,
+            );
 
-                    let verify_timeout = tokio::time::Duration::from_secs(300); // 5 min max
-                    let verify_future = verification_loop.verify_sandbox(
-                        sandbox_name,
-                        diff,
-                        &original_tasks,
-                        &topology,
-                        &agent_executor,
-                    );
-                    match tokio::time::timeout(verify_timeout, verify_future).await {
-                        Ok(Ok(vr)) => {
-                            log::info!(
-                                "  ✓ {} — {:?} ({} passed, {} failed)",
-                                sandbox_name,
-                                vr.status,
-                                vr.passed_tests.len(),
-                                vr.failed_tests.len()
-                            );
-                            sandbox_result.verification_status = vr.status.clone();
-                            verification_status.insert(sandbox_name.clone(), vr.status);
+            for (sandbox_name, sandbox_result) in &mut sandbox_results {
+                if let Some(ref diff) = sandbox_result.merged_diff.clone() {
+                    if !diff.is_empty() {
+                        let original_tasks: Vec<agentd_protocol::Task> = planner_output
+                            .task_graph
+                            .tasks
+                            .iter()
+                            .filter(|t| {
+                                planner_output
+                                    .sandbox_hints
+                                    .get(&t.id)
+                                    .map_or(false, |s| s == sandbox_name)
+                            })
+                            .cloned()
+                            .collect();
+
+                        let verify_timeout = tokio::time::Duration::from_secs(300); // 5 min max
+                        let verify_future = verification_loop.verify_sandbox(
+                            sandbox_name,
+                            diff,
+                            &original_tasks,
+                            &topology,
+                            &agent_executor,
+                            self.config.event_tx.as_ref(),
+                        );
+                        match tokio::time::timeout(verify_timeout, verify_future).await {
+                            Ok(Ok(vr)) => {
+                                let msg = format!(
+                                    "✓ [{}] Verification complete: {:?} — {} passed, {} failed",
+                                    sandbox_name,
+                                    vr.status,
+                                    vr.passed_tests.len(),
+                                    vr.failed_tests.len()
+                                );
+                                send_event(OrchestratorEvent::LayerProgress {
+                                    layer: 6,
+                                    message: msg.clone(),
+                                });
+                                log::info!("{}", msg);
+                                sandbox_result.verification_status = vr.status.clone();
+                                verification_status.insert(sandbox_name.clone(), vr.status);
+                            }
+                            Ok(Err(e)) => {
+                                let msg = format!(
+                                    "✗ [{}] Verification failed: {}",
+                                    sandbox_name, e
+                                );
+                                send_event(OrchestratorEvent::LayerProgress {
+                                    layer: 6,
+                                    message: msg.clone(),
+                                });
+                                log::warn!("{}", msg);
+                                sandbox_result.verification_status = VerificationStatus::Failed;
+                                verification_status.insert(sandbox_name.clone(), VerificationStatus::Failed);
+                            }
+                            Err(_) => {
+                                let timeout_secs = verify_timeout.as_secs();
+                                let msg = format!(
+                                    "✗ [{}] Verification timed out after {} seconds. \
+                                     Some tests may have been running. Marking as incomplete.",
+                                    sandbox_name, timeout_secs
+                                );
+                                send_event(OrchestratorEvent::LayerProgress {
+                                    layer: 6,
+                                    message: msg.clone(),
+                                });
+                                log::warn!("{}", msg);
+                                sandbox_result.verification_status = VerificationStatus::NotStarted;
+                                verification_status.insert(sandbox_name.clone(), VerificationStatus::NotStarted);
+                            }
                         }
-                        Ok(Err(e)) => {
-                            log::warn!("  ⚠ Verification failed for {}: {}", sandbox_name, e);
-                            sandbox_result.verification_status = VerificationStatus::Failed;
-                            verification_status.insert(sandbox_name.clone(), VerificationStatus::Failed);
-                        }
-                        Err(_) => {
-                            log::warn!("  ⚠ Verification timed out for {} after 5 minutes, skipping", sandbox_name);
-                            sandbox_result.verification_status = VerificationStatus::NotStarted;
-                            verification_status.insert(sandbox_name.clone(), VerificationStatus::NotStarted);
-                        }
+                    } else {
+                        sandbox_result.verification_status = VerificationStatus::NotStarted;
+                        verification_status.insert(sandbox_name.clone(), VerificationStatus::NotStarted);
                     }
                 } else {
                     sandbox_result.verification_status = VerificationStatus::NotStarted;
                     verification_status.insert(sandbox_name.clone(), VerificationStatus::NotStarted);
                 }
-            } else {
-                sandbox_result.verification_status = VerificationStatus::NotStarted;
-                verification_status.insert(sandbox_name.clone(), VerificationStatus::NotStarted);
             }
         }
 

--- a/agentd/src/orchestration/verification.rs
+++ b/agentd/src/orchestration/verification.rs
@@ -394,13 +394,30 @@ impl VerificationLoop {
         original_tasks: &[Task],
         topology: &TopologyManager,
         agent_executor: &AgentExecutor,
+        event_tx: Option<&std::sync::mpsc::Sender<super::OrchestratorEvent>>,
     ) -> Result<VerificationResult> {
+        // Helper to send events (no-op if event_tx is None)
+        let send_event = |msg: String| {
+            if let Some(tx) = event_tx {
+                let _ = tx.send(super::OrchestratorEvent::LayerProgress {
+                    layer: 6,
+                    message: msg,
+                });
+            }
+        };
+
         // Per-round vectors; cleared at the start of each round so the final
         // result reflects only what happened in the last completed round.
         let mut passed_tests: Vec<TaskId> = Vec::new();
         let mut failed_tests: Vec<TaskId> = Vec::new();
         let mut rounds_completed = 0;
 
+        let start_msg = format!(
+            "[Sandbox: {}] Running {} test round(s)...",
+            sandbox_name,
+            self.max_rounds
+        );
+        send_event(start_msg.clone());
         log::info!(
             "[VERIFY] Starting for sandbox: {}, diff_len: {}, tasks: {}",
             sandbox_name,
@@ -439,6 +456,8 @@ impl VerificationLoop {
             ];
 
             for test_task in &plan.test_tasks.tasks {
+                let test_msg = format!("  ✓ Test: {}", test_task.description);
+                send_event(test_msg);
                 log::info!("[VERIFY] Running test task: {}", test_task.id);
 
                 let agent = match topology
@@ -505,6 +524,8 @@ impl VerificationLoop {
 
                 match result {
                     Ok(r) if r.success => {
+                        let success_msg = format!("    ✓ {} passed", test_task.description);
+                        send_event(success_msg);
                         log::info!(
                             "[VERIFY] Test task {} finished: success=true",
                             test_task.id
@@ -513,6 +534,8 @@ impl VerificationLoop {
                     }
                     Ok(r) => {
                         let error = r.error.unwrap_or_else(|| "Test failed".to_string());
+                        let fail_msg = format!("    ✗ {} failed: {}", test_task.description, error);
+                        send_event(fail_msg);
                         log::info!(
                             "[VERIFY] Test task {} finished: success=false — {}",
                             test_task.id,
@@ -526,6 +549,14 @@ impl VerificationLoop {
                         ));
                     }
                     Err(e) => {
+                        let error_str = e.to_string();
+                        let is_timeout = error_str.contains("timeout");
+                        let fail_msg = if is_timeout {
+                            format!("    ✗ {} timed out after {}s", test_task.description, self.planner.max_test_execution_time)
+                        } else {
+                            format!("    ✗ {} failed: {}", test_task.description, error_str)
+                        };
+                        send_event(fail_msg);
                         log::info!(
                             "[VERIFY] Test task {} finished: success=false — {}",
                             test_task.id,
@@ -542,19 +573,26 @@ impl VerificationLoop {
             }
 
             if round_failures.is_empty() {
-                log::info!(
-                    "  ✓ All {} tests passed in round {}",
-                    passed_tests.len(),
-                    round + 1
+                let round_msg = format!(
+                    "✓ Round {}/{}: All {} tests passed",
+                    round + 1,
+                    self.max_rounds,
+                    passed_tests.len()
                 );
+                send_event(round_msg.clone());
+                log::info!("{}", round_msg);
                 break;
             }
 
-            log::info!(
-                "  ⚠ {} tests failed in round {}",
-                round_failures.len(),
-                round + 1
+            let round_msg = format!(
+                "⚠ Round {}/{}: {} tests passed, {} failed",
+                round + 1,
+                self.max_rounds,
+                passed_tests.len(),
+                round_failures.len()
             );
+            send_event(round_msg.clone());
+            log::info!("{}", round_msg);
 
             // Generate and execute fix tasks for failures (not on the last round)
             if round < self.max_rounds - 1 {
@@ -662,6 +700,14 @@ impl VerificationLoop {
             self.max_rounds,
         );
 
+        let final_msg = format!(
+            "✓ Verification complete: {:?} ({} passed, {} failed in {} round(s))",
+            status,
+            passed_tests.len(),
+            failed_tests.len(),
+            rounds_completed
+        );
+        send_event(final_msg.clone());
         log::info!(
             "[VERIFY] Done — sandbox: {}, status: {:?}, passed: {}, failed: {}, rounds: {}",
             sandbox_name,


### PR DESCRIPTION
Phase 1 fixes from the Layer 6 verification debug plan:

1. Add event channel logging to verification.rs
   - Pass event_tx to verify_sandbox() to emit real-time progress updates
   - Emit events on test start, completion, and round summary
   - Show test timeouts and failures with clear messaging

2. Improve gcloud authentication error messages in mod.rs
   - Detect specific error patterns (not found, permissions, auth config)
   - Provide actionable fix suggestions for each error type
   - Include stderr details to help user diagnose issues

3. Add pre-verification gcloud check in new_orchestrator.rs
   - Validate gcloud is available before Layer 6 starts
   - Skip verification gracefully if auth fails (don't hang)
   - Emit clear error event to TUI with troubleshooting steps
   - Track gcloud failures in known_issues

4. Improve timeout and error reporting
   - Better timeout messages showing seconds and sandbox name
   - Emit all verification results as TUI events
   - Distinguish timeout errors from other failures in output

All 43 orchestration tests pass. Fixes the issue where Layer 6
would hang silently or fail without visible user feedback.

https://claude.ai/code/session_012cWuMnZr9Tx9i1FJefc5uB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced gcloud authentication error messages with specific remediation commands and detailed guidance.
  * Added pre-flight authentication validation before verification begins.

* **Improvements**
  * Verification process now provides detailed progress updates at each stage.
  * Improved timeout and failure message formatting for clearer status communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->