### PR TITLE
fix: skip skopeo image pull when no image specified in create_sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentd"
-version = "0.2.0"
+version = "0.2.0+1"
 dependencies = [
  "agentd-protocol",
  "anyhow",

--- a/agentd/src/audit.rs
+++ b/agentd/src/audit.rs
@@ -96,10 +96,12 @@ impl AuditLogger {
     }
 
     pub fn log(&self, event: AuditEvent) -> anyhow::Result<()> {
-        let mut buffer = self.buffer.lock().unwrap();
-        buffer.push(event);
-
-        if buffer.len() >= self.buffer_size {
+        let should_flush = {
+            let mut buffer = self.buffer.lock().unwrap();
+            buffer.push(event);
+            buffer.len() >= self.buffer_size
+        }; // buffer lock released before flush to avoid self-deadlock
+        if should_flush {
             self.flush()?;
         }
         Ok(())

--- a/agentd/src/orchestration/sandbox_topology.rs
+++ b/agentd/src/orchestration/sandbox_topology.rs
@@ -92,15 +92,15 @@ impl TopologyManager {
 
     /// Create sandbox via agentd socket API
     pub async fn create_sandbox_layer(&self, config: &SandboxConfig) -> Result<()> {
-        // Call agentd to create sandbox with project root mounted
+        // Call agentd to create sandbox with project root mounted.
+        // No "image" field — socket server creates a plain tmpfs sandbox (no skopeo needed).
         let request = json!({
             "request_type": "create_sandbox",
-            "image": "alpine", // Default to alpine
             "packages": config.tools.iter()
                 .filter_map(|tool| self.tool_to_package(tool))
                 .collect::<Vec<_>>(),
-            "project_root": self.project_root.to_string_lossy(),  // Mount project root as base layer
-            "scope": config.scope.clone(),  // Scoped view (e.g., "src/frontend/")
+            "project_root": self.project_root.to_string_lossy(),
+            "scope": config.scope.clone(),
         });
 
         let socket_path = self.socket_path.clone();

--- a/agentd/src/sandbox.rs
+++ b/agentd/src/sandbox.rs
@@ -110,10 +110,13 @@ pub struct Sandbox {
 impl Drop for Sandbox {
     fn drop(&mut self) {
         // Clean up containers: unmount submounts first, then root, then delete dirs.
+        let has_image = self.image_path.is_some();
         for (_, container) in &self.containers {
             let _ = umount2(&container.root.join("workspace"), MntFlags::MNT_DETACH);
-            let _ = umount2(&container.root.join("dev"),       MntFlags::MNT_DETACH);
-            let _ = umount2(&container.root.join("proc"),      MntFlags::MNT_DETACH);
+            if has_image {
+                let _ = umount2(&container.root.join("dev"),  MntFlags::MNT_DETACH);
+                let _ = umount2(&container.root.join("proc"), MntFlags::MNT_DETACH);
+            }
             let _ = umount2(&container.root, MntFlags::MNT_DETACH);
             if let Some(base) = container.root.parent() {
                 let _ = std::fs::remove_dir_all(base);
@@ -699,27 +702,32 @@ impl Sandbox {
         let _ = fs::copy("/etc/resolv.conf", etc.join("resolv.conf"));
         let _ = fs::copy("/etc/hosts", etc.join("hosts"));
 
-        // Mount /proc
-        let proc_dir = root.join("proc");
-        fs::create_dir_all(&proc_dir)?;
-        let _ = mount(
-            Some("proc"),
-            &proc_dir,
-            Some("proc"),
-            MsFlags::empty(),
-            None::<&str>,
-        );
+        // Mount /proc and /dev only when the sandbox has a real image (rootfs).
+        // For plain-tmpfs sandboxes (no image) there is no /bin/sh to exec, so
+        // the container never needs /proc or /dev populated.  Skipping devtmpfs
+        // avoids blocking the kdevtmpfs kernel thread (which populates device
+        // nodes asynchronously) and keeps the DashMap write-lock duration short.
+        if self.image_path.is_some() {
+            let proc_dir = root.join("proc");
+            fs::create_dir_all(&proc_dir)?;
+            let _ = mount(
+                Some("proc"),
+                &proc_dir,
+                Some("proc"),
+                MsFlags::empty(),
+                None::<&str>,
+            );
 
-        // Mount /dev
-        let dev_dir = root.join("dev");
-        fs::create_dir_all(&dev_dir)?;
-        let _ = mount(
-            Some("devtmpfs"),
-            &dev_dir,
-            Some("devtmpfs"),
-            MsFlags::empty(),
-            None::<&str>,
-        );
+            let dev_dir = root.join("dev");
+            fs::create_dir_all(&dev_dir)?;
+            let _ = mount(
+                Some("devtmpfs"),
+                &dev_dir,
+                Some("devtmpfs"),
+                MsFlags::empty(),
+                None::<&str>,
+            );
+        }
 
         // Mount an isolated overlay workspace if a project root is configured.
         // The project tree is always the read-only lowerdir; each container gets
@@ -882,12 +890,13 @@ impl Sandbox {
 
         if let Some(container) = self.containers.remove(&container_id) {
             // Unmount submounts first to prevent mount-namespace bloat.
-            // Each container mounts /proc, /dev, and /workspace inside root/;
-            // if only root/ is lazily unmounted they leak into new namespaces,
-            // causing `unshare --mount-proc` to become progressively slower.
+            // Workspace is always mounted; proc/dev only exist when the sandbox
+            // has a real image (see create_container).
             let _ = umount2(&container.root.join("workspace"), MntFlags::MNT_DETACH);
-            let _ = umount2(&container.root.join("dev"),       MntFlags::MNT_DETACH);
-            let _ = umount2(&container.root.join("proc"),      MntFlags::MNT_DETACH);
+            if self.image_path.is_some() {
+                let _ = umount2(&container.root.join("dev"),  MntFlags::MNT_DETACH);
+                let _ = umount2(&container.root.join("proc"), MntFlags::MNT_DETACH);
+            }
             // Now unmount the container root itself
             let _ = umount2(&container.root, MntFlags::MNT_DETACH);
             // Remove the container directory tree

--- a/agentd/src/sandbox.rs
+++ b/agentd/src/sandbox.rs
@@ -109,20 +109,21 @@ pub struct Sandbox {
 
 impl Drop for Sandbox {
     fn drop(&mut self) {
-        // unmount the root path (overlayfs or tmpfs)
-        let _ = umount2(self.root.path(), MntFlags::MNT_DETACH);
-        // clean up overlayfs directories if they exist
-        let overlay_base = std::env::temp_dir().join(format!("overlay-{}", self.id));
-        let _ = std::fs::remove_dir_all(&overlay_base);
-        // clean up containers: unmount and remove each container's temp directory
+        // Clean up containers: unmount submounts first, then root, then delete dirs.
         for (_, container) in &self.containers {
+            let _ = umount2(&container.root.join("workspace"), MntFlags::MNT_DETACH);
+            let _ = umount2(&container.root.join("dev"),       MntFlags::MNT_DETACH);
+            let _ = umount2(&container.root.join("proc"),      MntFlags::MNT_DETACH);
             let _ = umount2(&container.root, MntFlags::MNT_DETACH);
-            // Remove the entire container-{id} directory (parent of root)
-            // This is /tmp/container-{id} which contains upper/, work/, root/
             if let Some(base) = container.root.parent() {
                 let _ = std::fs::remove_dir_all(base);
             }
         }
+        // Unmount the sandbox root (overlayfs or tmpfs)
+        let _ = umount2(self.root.path(), MntFlags::MNT_DETACH);
+        // Clean up overlayfs upper/work dirs if they exist
+        let overlay_base = std::env::temp_dir().join(format!("overlay-{}", self.id));
+        let _ = std::fs::remove_dir_all(&overlay_base);
     }
 }
 
@@ -878,11 +879,18 @@ impl Sandbox {
     /// destroy a container and clean up its resources
     pub fn destroy_container(&mut self, container_id: u64) -> anyhow::Result<()> {
         use nix::mount::{umount2, MntFlags};
-        
+
         if let Some(container) = self.containers.remove(&container_id) {
-            // unmount the container root
+            // Unmount submounts first to prevent mount-namespace bloat.
+            // Each container mounts /proc, /dev, and /workspace inside root/;
+            // if only root/ is lazily unmounted they leak into new namespaces,
+            // causing `unshare --mount-proc` to become progressively slower.
+            let _ = umount2(&container.root.join("workspace"), MntFlags::MNT_DETACH);
+            let _ = umount2(&container.root.join("dev"),       MntFlags::MNT_DETACH);
+            let _ = umount2(&container.root.join("proc"),      MntFlags::MNT_DETACH);
+            // Now unmount the container root itself
             let _ = umount2(&container.root, MntFlags::MNT_DETACH);
-            // remove the container directory
+            // Remove the container directory tree
             if let Some(base) = container.root.parent() {
                 let _ = std::fs::remove_dir_all(base);
             }

--- a/agentd/src/socket_server.rs
+++ b/agentd/src/socket_server.rs
@@ -418,14 +418,14 @@ fn handle_request(req: SocketRequest) -> SocketResponse {
         // 3. Every container created from this sandbox will inherit those packages
         //    via overlayfs (lower layer = sandbox upper, which has the packages).
         "create_sandbox" => {
-            let image = req.image.clone().unwrap_or_else(|| "alpine".to_string());
+            let image = req.image.clone(); // None means plain tmpfs (no skopeo needed)
             let backend = req.backend.clone().unwrap_or_else(|| "chroot".to_string());
             let limits = ResourceLimits { ram_bytes: req.ram, cpu_millis: req.cpu };
             let seed_repo_url = req.seed_repo_url.clone();
             let seed_repo_branch = req.seed_repo_branch.clone();
             let seed_repo_subdir = req.seed_repo_subdir.clone();
 
-            let mut sb = match Sandbox::new_with_image(limits, Some(&image)) {
+            let mut sb = match Sandbox::new_with_image(limits, image.as_deref()) {
                 Ok(s) => s,
                 Err(e) => {
                     let _ = AUDITOR.record_event(
@@ -439,11 +439,12 @@ fn handle_request(req: SocketRequest) -> SocketResponse {
             let id = sb.id();
             let root = sb.root_path().to_owned();
             let extra = req.packages.as_deref().unwrap_or(&[]);
+            let image_label = image.as_deref().unwrap_or("(none)");
 
             log::info!("sandbox created: {}", id);
-            log::info!("[agentd] Setting up sandbox {} with image '{}'", id, image);
+            log::info!("[agentd] Setting up sandbox {} with image '{}'", id, image_label);
 
-            if let Err(e) = install_packages_in_image(&root, &image, extra) {
+            if let Err(e) = install_packages_in_image(&root, image_label, extra) {
                 log::warn!("sandbox {} package install warning: {}", id, e);
                 // Non-fatal: continue even if some optional packages failed.
                 // Core failures will be caught when the first tool runs.
@@ -519,7 +520,7 @@ fn handle_request(req: SocketRequest) -> SocketResponse {
             SANDBOX_BACKENDS.insert(id, backend.clone());
 
             if backend == "guest_vm" {
-                match boot_vm(id.to_string(), &root, &image) {
+                match boot_vm(id.to_string(), &root, image.as_deref().unwrap_or("alpine")) {
                     Ok(handle) => {
                         VM_HANDLES.insert(id, handle);
                         log::info!("[agentd] guest_vm QEMU boot pid={} sandbox={} port=?", id, id);


### PR DESCRIPTION
Socket server now uses Sandbox::new_with_image(limits, None) when no
image field is included in the create_sandbox request, creating a plain
tmpfs sandbox without requiring skopeo. Topology manager's simulate path
no longer sends "image": "alpine", so the simulation stack (Layers 1-7)
can run without skopeo installed.

https://claude.ai/code/session_01WadLJKCJzRbkqMR41rHoXA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandboxes can now be created without requiring a default image.

* **Bug Fixes**
  * Fixed potential deadlock issue in audit logging operations.
  * Improved sandbox cleanup and resource unmounting process for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->