### PR TITLE
feat: make orchestration pipeline provider-agnostic

### DIFF
--- a/agentd/src/main.rs
+++ b/agentd/src/main.rs
@@ -113,8 +113,14 @@ fn main() -> Result<()> {
             let checkpoint_root = std::env::temp_dir().join("mowisai-checkpoints");
             let merge_work_dir = std::env::temp_dir().join("mowisai-merge");
 
+            // Build LlmConfig: prefer saved MowisConfig; fall back to Vertex AI with --project flag
+            let llm_config = MowisConfig::load()
+                .ok()
+                .and_then(|cfg| libagent::orchestration::provider_client::LlmConfig::from_config(&cfg).ok())
+                .unwrap_or_else(|| libagent::orchestration::provider_client::LlmConfig::vertex(&cmd.project));
+
             let config = libagent::orchestration::new_orchestrator::OrchestratorConfig {
-                project_id: cmd.project.clone(),
+                llm_config,
                 socket_path: cmd.socket.clone(),
                 project_root: project_root.clone(),
                 overlay_root,

--- a/agentd/src/orchestration/agent_execution.rs
+++ b/agentd/src/orchestration/agent_execution.rs
@@ -1,6 +1,7 @@
-//! Layer 4: Agent Execution — Gemini tool-calling loop with checkpoint system
+//! Layer 4: Agent Execution — provider-agnostic tool-calling loop with checkpoint system
 
 use super::checkpoint::{CheckpointLog, CheckpointManager};
+use super::provider_client::{AgentConversation, AgentRoundResult, LlmConfig, ToolCall};
 use agentd_protocol::{AgentHandle, AgentResult, Checkpoint};
 use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
@@ -11,19 +12,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Global flag for verbose output
 static VERBOSE_MODE: AtomicBool = AtomicBool::new(false);
 
-/// Enable or disable verbose mode
 pub fn set_verbose(enabled: bool) {
     VERBOSE_MODE.store(enabled, Ordering::Relaxed);
 }
 
-/// Check if verbose mode is enabled
 pub fn is_verbose() -> bool {
     VERBOSE_MODE.load(Ordering::Relaxed)
 }
 
 /// Agent executor with checkpoint support
 pub struct AgentExecutor {
-    project_id: String,
+    llm_config: LlmConfig,
     socket_path: String,
     checkpoint_manager: CheckpointManager,
     max_tool_rounds: usize,
@@ -33,12 +32,12 @@ pub struct AgentExecutor {
 
 impl AgentExecutor {
     pub fn new(
-        project_id: String,
+        llm_config: LlmConfig,
         socket_path: String,
         checkpoint_root: PathBuf,
     ) -> Result<Self> {
         Ok(Self {
-            project_id,
+            llm_config,
             socket_path: socket_path.clone(),
             checkpoint_manager: CheckpointManager::new(checkpoint_root, socket_path)?,
             max_tool_rounds: super::MAX_TOOL_ROUNDS,
@@ -57,7 +56,7 @@ impl AgentExecutor {
     ) -> Result<AgentResult> {
         if is_verbose() {
             log::info!("\n┌─────────────────────────────────────────────────────────");
-            log::info!("│ 🤖 AGENT: {}", &agent.agent_id[..8]);
+            log::info!("│ 🤖 AGENT: {}", &agent.agent_id[..8.min(agent.agent_id.len())]);
             log::info!("│ 📋 TASK: {}", task_description);
             log::info!("│ 🛠️  TOOLS: {:?}", tools);
             log::info!("└─────────────────────────────────────────────────────────");
@@ -84,7 +83,6 @@ impl AgentExecutor {
                 .await
             {
                 Ok(result) => {
-                    // Success - cleanup checkpoints
                     self.checkpoint_manager
                         .cleanup_agent_checkpoints(&agent.agent_id)
                         .ok();
@@ -100,32 +98,42 @@ impl AgentExecutor {
 
                     // Tier 2: Restore from last checkpoint
                     if let Some(last_checkpoint) = checkpoint_log.latest() {
-                        let snapshot_path = PathBuf::from(&last_checkpoint.layer_snapshot_path);
+                        let snapshot_path =
+                            PathBuf::from(&last_checkpoint.layer_snapshot_path);
 
                         if snapshot_path.exists() {
                             match self.checkpoint_manager.restore_snapshot(
                                 &agent.sandbox_name,
                                 &agent.container_id,
-                                &snapshot_path
+                                &snapshot_path,
                             ) {
                                 Ok(()) => {
-                                    log::info!("  ✓ Restored checkpoint {} for agent {}",
-                                        last_checkpoint.id, &agent.agent_id[..8]);
+                                    log::info!(
+                                        "  ✓ Restored checkpoint {} for agent {}",
+                                        last_checkpoint.id,
+                                        &agent.agent_id[..8.min(agent.agent_id.len())]
+                                    );
                                 }
                                 Err(restore_err) => {
-                                    log::warn!("  ⚠ Checkpoint restore failed: {}", restore_err);
+                                    log::warn!(
+                                        "  ⚠ Checkpoint restore failed: {}",
+                                        restore_err
+                                    );
                                 }
                             }
                         }
                     }
                 }
                 Err(e) => {
-                    // Tier 3: Escalate to human
                     return Ok(AgentResult {
                         task_id: agent.task_id.clone().unwrap_or_default(),
                         success: false,
                         git_diff: None,
-                        error: Some(format!("Task failed after {} retries: {}", tier2_attempt + 1, e)),
+                        error: Some(format!(
+                            "Task failed after {} retries: {}",
+                            tier2_attempt + 1,
+                            e
+                        )),
                         checkpoint_log: checkpoint_log.checkpoints.clone(),
                         timestamp: current_timestamp(),
                     });
@@ -133,7 +141,6 @@ impl AgentExecutor {
             }
         }
 
-        // Should not reach here
         Ok(AgentResult {
             task_id: agent.task_id.clone().unwrap_or_default(),
             success: false,
@@ -144,7 +151,7 @@ impl AgentExecutor {
         })
     }
 
-    /// Execute with checkpoint support
+    /// Execute with checkpoint support using the provider-agnostic tool loop.
     async fn execute_with_checkpoints(
         &self,
         agent: &AgentHandle,
@@ -153,42 +160,42 @@ impl AgentExecutor {
         system_prompt: &str,
         checkpoint_log: &mut CheckpointLog,
     ) -> Result<AgentResult> {
-        let access_token = super::gcloud_access_token()?;
-        let url = super::vertex_generate_url(&self.project_id);
+        let mut conversation = AgentConversation::new();
 
-        let mut conversation: Vec<Value> = vec![json!({
-            "role": "user",
-            "parts": [{"text": format!(
-                "IMPORTANT: All file paths MUST start with /workspace (the project directory).\n\n\
-                Task: {}\n\n\
-                You have access to these tools: {:?}\n\n\
-                Complete this task using the available tools.\n\n\
-                When using file tools, always use absolute paths starting with /workspace:\n\
-                - read_file: path=/workspace/src/file.rs\n\
-                - write_file: path=/workspace/src/new_file.rs\n\
-                - run_command: Use 'cd /workspace && ...' to change directory first",
-                task_description,
-                tools
-            )}]
-        })];
+        // Initial user message
+        conversation.push_user(format!(
+            "IMPORTANT: All file paths MUST start with /workspace (the project directory).\n\n\
+            Task: {}\n\n\
+            You have access to these tools: {:?}\n\n\
+            Complete this task using the available tools.\n\n\
+            When using file tools, always use absolute paths starting with /workspace:\n\
+            - read_file: path=/workspace/src/file.rs\n\
+            - write_file: path=/workspace/src/new_file.rs\n\
+            - run_command: Use 'cd /workspace && ...' to change directory first",
+            task_description,
+            tools
+        ));
 
         // Restore from checkpoint if any
         if checkpoint_log.latest().is_some() {
-            // Add checkpoint history to context
             let checkpoint_summary = checkpoint_log
                 .checkpoints
                 .iter()
-                .map(|c| format!("- {} with args {:?} -> {}", c.tool_call, c.tool_args, c.tool_result))
+                .map(|c| {
+                    format!(
+                        "- {} with args {:?} -> {}",
+                        c.tool_call, c.tool_args, c.tool_result
+                    )
+                })
                 .collect::<Vec<_>>()
                 .join("\n");
 
-            conversation.push(json!({
-                "role": "user",
-                "parts": [{"text": format!("Previous work (recovered from checkpoint):\n{}", checkpoint_summary)}]
-            }));
+            conversation.push_user(format!(
+                "Previous work (recovered from checkpoint):\n{}",
+                checkpoint_summary
+            ));
         }
 
-        // Enhanced system prompt that forbids placeholders
         let enhanced_system_prompt = format!(
             "{}\n\n\
             CRITICAL REQUIREMENTS:\n\
@@ -223,141 +230,24 @@ impl AgentExecutor {
 
         // Tool-calling loop
         for _ in 0..self.max_tool_rounds {
-            let request_body = json!({
-                "contents": conversation,
-                "systemInstruction": {
-                    "parts": [{"text": enhanced_system_prompt}]
-                },
-                "tools": [{
-                    "functionDeclarations": build_tool_declarations(tools)
-                }],
-                "generationConfig": super::vertex_generation_config(0.7)
-            });
+            let round_result = super::provider_client::call_agent_round(
+                &self.llm_config,
+                &enhanced_system_prompt,
+                &mut conversation,
+                tools,
+                0.7,
+            )
+            .await
+            .context("LLM call failed in agent tool loop")?;
 
-            let client = reqwest::Client::new();
-            let response = client
-                .post(&url)
-                .header("Authorization", format!("Bearer {}", access_token))
-                .header("Content-Type", "application/json")
-                .json(&request_body)
-                .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS))
-                .send()
-                .await
-                .context("Failed to send request to Gemini")?;
-
-            if !response.status().is_success() {
-                let error_text = response.text().await.unwrap_or_default();
-                return Err(anyhow!("Gemini API error: {}", error_text));
-            }
-
-            let response_json: Value = response.json().await.context("Failed to parse Gemini response")?;
-
-            // Extract candidate
-            let candidate = response_json
-                .get("candidates")
-                .and_then(|c| c.get(0))
-                .ok_or_else(|| anyhow!("No candidates in response"))?;
-
-            let content = candidate
-                .get("content")
-                .ok_or_else(|| anyhow!("No content in candidate"))?;
-
-            // Add assistant response to conversation
-            conversation.push(content.clone());
-
-            // Check for function calls
-            let parts = content
-                .get("parts")
-                .and_then(|p| p.as_array())
-                .ok_or_else(|| anyhow!("No parts in content"))?;
-
-            let mut function_responses = Vec::new();
-            let mut has_function_calls = false;
-
-            for part in parts {
-                if let Some(function_call) = part.get("functionCall") {
-                    has_function_calls = true;
-                    let tool_name = function_call
-                        .get("name")
-                        .and_then(|n| n.as_str())
-                        .ok_or_else(|| anyhow!("Missing function name"))?;
-
-                    let tool_args = function_call
-                        .get("args")
-                        .cloned()
-                        .unwrap_or(json!({}));
-
-                    if is_verbose() {
-                        log::info!("  🔧 Calling tool: {} with args: {}", tool_name, tool_args);
-                    }
-
-                    // Execute tool with tier 1 retry support
-                    let tool_result = self
-                        .execute_tool_with_retry(
-                            &agent.sandbox_name,
-                            &agent.container_id,
-                            tool_name,
-                            &tool_args,
-                        )
-                        .await?;
-
-        // Create checkpoint after successful tool call
-        let checkpoint_id = checkpoint_log.checkpoints.len() as u64;
-
-        // Create snapshot via agentd socket (runs as root, can access container upper layer)
-        let snapshot_path = self.checkpoint_manager.create_snapshot(
-            &agent.agent_id,
-            checkpoint_id,
-            &agent.sandbox_name,
-            &agent.container_id,
-        )?;
-
-        let checkpoint = Checkpoint {
-            id: checkpoint_id,
-            tool_call: tool_name.to_string(),
-            tool_args: tool_args.clone(),
-            tool_result: serde_json::to_string(&tool_result)?,
-            timestamp: current_timestamp(),
-            layer_snapshot_path: snapshot_path.to_string_lossy().to_string(),
-        };
-
-        checkpoint_log.add_checkpoint(checkpoint)?;
-
-        // Prune old checkpoints (keep last 5)
-        checkpoint_log.prune(5)?;
-
-                    if is_verbose() {
-                        // Show tool result preview
-                        let result_str = serde_json::to_string_pretty(&tool_result).unwrap_or_default();
-                        let preview = if result_str.len() > 200 {
-                            format!("{}... ({} bytes)", &result_str[..200], result_str.len())
-                        } else {
-                            result_str
-                        };
-                        log::info!("  ✅ Result: {}", preview);
-                    }
-
-                    function_responses.push(json!({
-                        "functionResponse": {
-                            "name": tool_name,
-                            "response": tool_result
-                        }
-                    }));
-                }
-            }
-
-            if !has_function_calls {
-                // Agent finished - extract final text and git diff
-                let final_text = parts
-                    .iter()
-                    .find_map(|p| p.get("text").and_then(|t| t.as_str()))
-                    .unwrap_or("");
+            if round_result.tool_calls.is_empty() {
+                // Agent finished — capture text and git diff
+                let final_text = round_result.text.unwrap_or_default();
 
                 if is_verbose() {
                     log::info!("\n  💬 Agent says: {}", final_text);
                 }
 
-                // Capture git diff from agent's layer
                 let git_diff = self.capture_git_diff(agent).await.ok();
 
                 if is_verbose() {
@@ -368,7 +258,10 @@ impl AgentExecutor {
                             log::info!("  │ {}", line);
                         }
                         if diff.lines().count() > 20 {
-                            log::info!("  │ ... ({} more lines)", diff.lines().count() - 20);
+                            log::info!(
+                                "  │ ... ({} more lines)",
+                                diff.lines().count() - 20
+                            );
                         }
                         log::info!("  └─────────────────────────────────────────");
                     } else {
@@ -386,13 +279,64 @@ impl AgentExecutor {
                 });
             }
 
-            // Add function responses to conversation
-            if !function_responses.is_empty() {
-                conversation.push(json!({
-                    "role": "function",
-                    "parts": function_responses
-                }));
+            // Execute each tool call, creating a checkpoint after each success
+            let mut round_results: Vec<(ToolCall, Value)> = Vec::new();
+
+            for tool_call in round_result.tool_calls {
+                if is_verbose() {
+                    log::info!(
+                        "  🔧 Calling tool: {} with args: {}",
+                        tool_call.name,
+                        tool_call.args
+                    );
+                }
+
+                let tool_result = self
+                    .execute_tool_with_retry(
+                        &agent.sandbox_name,
+                        &agent.container_id,
+                        &tool_call.name,
+                        &tool_call.args,
+                    )
+                    .await?;
+
+                // Checkpoint after every successful tool call
+                let checkpoint_id = checkpoint_log.checkpoints.len() as u64;
+                let snapshot_path = self.checkpoint_manager.create_snapshot(
+                    &agent.agent_id,
+                    checkpoint_id,
+                    &agent.sandbox_name,
+                    &agent.container_id,
+                )?;
+
+                let checkpoint = Checkpoint {
+                    id: checkpoint_id,
+                    tool_call: tool_call.name.clone(),
+                    tool_args: tool_call.args.clone(),
+                    tool_result: serde_json::to_string(&tool_result)?,
+                    timestamp: current_timestamp(),
+                    layer_snapshot_path: snapshot_path.to_string_lossy().to_string(),
+                };
+
+                checkpoint_log.add_checkpoint(checkpoint)?;
+                checkpoint_log.prune(5)?;
+
+                if is_verbose() {
+                    let result_str =
+                        serde_json::to_string_pretty(&tool_result).unwrap_or_default();
+                    let preview = if result_str.len() > 200 {
+                        format!("{}... ({} bytes)", &result_str[..200], result_str.len())
+                    } else {
+                        result_str
+                    };
+                    log::info!("  ✅ Result: {}", preview);
+                }
+
+                round_results.push((tool_call, tool_result));
             }
+
+            // Feed all tool results back to the conversation in one batch
+            conversation.push_tool_results(round_results);
         }
 
         Err(anyhow!("Max tool rounds exceeded"))
@@ -437,8 +381,13 @@ impl AgentExecutor {
         tool_name: &str,
         tool_args: &Value,
     ) -> Result<Value> {
-        let result =
-            super::invoke_tool_via_socket(&self.socket_path, sandbox_name, container_id, tool_name, tool_args)?;
+        let result = super::invoke_tool_via_socket(
+            &self.socket_path,
+            sandbox_name,
+            container_id,
+            tool_name,
+            tool_args,
+        )?;
 
         if let Some(error) = result.get("error") {
             return Err(anyhow!("Tool error: {}", error));
@@ -507,25 +456,6 @@ impl AgentExecutor {
     }
 }
 
-/// Build tool declarations for Gemini
-fn build_tool_declarations(tools: &[String]) -> Vec<Value> {
-    let all_tools = super::gemini_tool_declarations();
-    let empty_vec = vec![];
-    let all_tools_array = all_tools.as_array().unwrap_or(&empty_vec);
-
-    all_tools_array
-        .iter()
-        .filter(|tool| {
-            tool.get("name")
-                .and_then(|n| n.as_str())
-                .map(|name| tools.contains(&name.to_string()))
-                .unwrap_or(false)
-        })
-        .cloned()
-        .collect()
-}
-
-/// Get current Unix timestamp
 fn current_timestamp() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -538,9 +468,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_tool_declarations() {
-        let tools = vec!["read_file".to_string(), "write_file".to_string()];
-        let declarations = build_tool_declarations(&tools);
-        assert_eq!(declarations.len(), 2);
+    fn test_current_timestamp_is_nonzero() {
+        assert!(current_timestamp() > 0);
     }
 }

--- a/agentd/src/orchestration/merge_reviewer.rs
+++ b/agentd/src/orchestration/merge_reviewer.rs
@@ -4,6 +4,7 @@
 //! parses unified diffs, detects semantic conflicts, and uses Gemini to make intelligent
 //! merge decisions.
 
+use super::provider_client::{generate_text, LlmConfig};
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -379,16 +380,16 @@ fn hunks_overlap_between_agents(agent_entries: &[(usize, &FileChange)]) -> bool 
 // ── Merge Reviewer Agent ─────────────────────────────────────────────────────
 
 /// LLM-powered merge reviewer. Auto-accepts conflict-free changes and uses
-/// Gemini to resolve any detected conflicts.
+/// an LLM to resolve any detected conflicts.
 pub struct MergeReviewerAgent {
-    project_id: String,
+    llm_config: LlmConfig,
     max_retries: usize,
 }
 
 impl MergeReviewerAgent {
-    pub fn new(project_id: String) -> Self {
+    pub fn new(llm_config: LlmConfig) -> Self {
         Self {
-            project_id,
+            llm_config,
             max_retries: 3,
         }
     }
@@ -482,7 +483,7 @@ impl MergeReviewerAgent {
 
         let prompt = self.build_conflict_prompt(&conflicts, &file_map, &contributions);
 
-        let llm_raw = self.call_gemini(&prompt).await?;
+        let llm_raw = self.call_llm(&prompt).await?;
         let conflict_decisions = parse_llm_decisions(&llm_raw, &conflicts);
 
         let mut conflicts_resolved = 0usize;
@@ -624,72 +625,37 @@ Output ONLY the JSON array, no other text."#,
         )
     }
 
-    /// Call Gemini with the conflict resolution prompt and return the raw response text.
-    async fn call_gemini(&self, prompt: &str) -> Result<String> {
-        let access_token = super::gcloud_access_token()?;
-        let url = super::vertex_generate_url(&self.project_id);
-
-        let request_body = json!({
-            "contents": [
-                {
-                    "role": "user",
-                    "parts": [{"text": prompt}]
-                }
-            ],
-            "systemInstruction": {
-                "parts": [{
-                    "text": "You are a senior software engineer resolving merge conflicts. Respond ONLY with a valid JSON array."
-                }]
-            },
-            "generationConfig": super::vertex_generation_config_json(0.2)
-        });
-
-        let client = reqwest::Client::new();
+    /// Call the configured LLM with the conflict resolution prompt.
+    async fn call_llm(&self, prompt: &str) -> Result<String> {
+        let system_prompt = "You are a senior software engineer resolving merge conflicts. Respond ONLY with a valid JSON array.";
         let mut last_err: Option<anyhow::Error> = None;
 
         for attempt in 0..self.max_retries {
-            let response = client
-                .post(&url)
-                .header("Authorization", format!("Bearer {}", access_token))
-                .header("Content-Type", "application/json")
-                .json(&request_body)
-                .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS))
-                .send()
-                .await
-                .context("Failed to send conflict review request to Gemini")?;
-
-            if !response.status().is_success() {
-                let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                let err = anyhow!("Gemini API returned {}: {}", status, body);
-                if attempt < self.max_retries - 1 {
-                    log::info!("⚠️  MergeReviewer attempt {}/{} failed: {}", attempt + 1, self.max_retries, status);
-                    tokio::time::sleep(tokio::time::Duration::from_secs(2u64.pow(attempt as u32))).await;
-                    last_err = Some(err);
-                    continue;
+            match generate_text(&self.llm_config, system_prompt, prompt, true, 0.2).await {
+                Ok(text) => return Ok(text),
+                Err(e) => {
+                    if attempt < self.max_retries - 1 {
+                        log::info!(
+                            "⚠️  MergeReviewer attempt {}/{} failed: {}",
+                            attempt + 1,
+                            self.max_retries,
+                            e
+                        );
+                        tokio::time::sleep(tokio::time::Duration::from_secs(
+                            2u64.pow(attempt as u32),
+                        ))
+                        .await;
+                        last_err = Some(e);
+                    } else {
+                        return Err(e);
+                    }
                 }
-                return Err(err);
             }
-
-            let response_json: serde_json::Value = response
-                .json()
-                .await
-                .context("Failed to parse Gemini response JSON")?;
-
-            let text = response_json
-                .get("candidates")
-                .and_then(|c| c.get(0))
-                .and_then(|c| c.get("content"))
-                .and_then(|c| c.get("parts"))
-                .and_then(|p| p.get(0))
-                .and_then(|p| p.get("text"))
-                .and_then(|t| t.as_str())
-                .ok_or_else(|| anyhow!("Unexpected Gemini response structure — missing candidates[0].content.parts[0].text"))?;
-
-            return Ok(text.to_string());
         }
 
-        Err(last_err.unwrap_or_else(|| anyhow!("Gemini call failed after {} attempts", self.max_retries)))
+        Err(last_err.unwrap_or_else(|| {
+            anyhow!("LLM call failed after {} attempts", self.max_retries)
+        }))
     }
 }
 

--- a/agentd/src/orchestration/mod.rs
+++ b/agentd/src/orchestration/mod.rs
@@ -15,6 +15,7 @@ pub mod mock_agent;
 pub mod simulate;
 pub mod health;
 pub mod complexity_classifier;
+pub mod provider_client;
 
 // Re-export main types
 pub use new_orchestrator::{NewOrchestrator, OrchestratorConfig, FinalOutput, OrchestratorEvent};

--- a/agentd/src/orchestration/new_orchestrator.rs
+++ b/agentd/src/orchestration/new_orchestrator.rs
@@ -52,7 +52,8 @@ pub struct FailedTask {
 
 /// Main orchestrator configuration
 pub struct OrchestratorConfig {
-    pub project_id: String,
+    /// Provider credentials and model selection (replaces the old `project_id` field).
+    pub llm_config: super::provider_client::LlmConfig,
     pub socket_path: String,
     pub project_root: PathBuf,
     pub overlay_root: PathBuf,
@@ -149,7 +150,7 @@ impl NewOrchestrator {
         // â”€â”€ Full mode: Layer 1 â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         send_event!(OrchestratorEvent::LayerProgress { layer: 1, message: "Planning tasks...".into() });
         log::info!("Layer 1: Planning tasks (full mode)...");
-        let planner_output = plan_task(prompt, &self.config.project_root, &self.config.project_id)
+        let planner_output = plan_task(prompt, &self.config.project_root, &self.config.llm_config)
             .await
             .context("Fast planner failed")?;
 
@@ -188,7 +189,7 @@ impl NewOrchestrator {
         send_event!(OrchestratorEvent::LayerProgress { layer: 4, message: "Executing tasks with agents...".into() });
         log::info!("Layer 4: Executing tasks with agents...");
         let agent_executor = Arc::new(AgentExecutor::new(
-            self.config.project_id.clone(),
+            self.config.llm_config.clone(),
             self.config.socket_path.clone(),
             self.config.checkpoint_root.clone(),
         )?);
@@ -466,7 +467,7 @@ impl NewOrchestrator {
 
         // Layer 5: Intelligent Merge Review (per sandbox)
         log::info!("Layer 5: Reviewing and merging agent contributions per sandbox...");
-        let reviewer = MergeReviewerAgent::new(self.config.project_id.clone());
+        let reviewer = MergeReviewerAgent::new(self.config.llm_config.clone());
         let mut sandbox_results = HashMap::new();
 
         for (sandbox_name, agent_work_results) in &sandbox_agent_results {
@@ -564,7 +565,7 @@ impl NewOrchestrator {
         log::info!("Layer 6: Verifying sandbox results...");
 
         let verification_loop = VerificationLoop::new(
-            self.config.project_id.clone(),
+            self.config.llm_config.clone(),
             self.config.max_verification_rounds,
         );
 
@@ -804,7 +805,7 @@ impl NewOrchestrator {
         });
 
         let executor = AgentExecutor::new(
-            self.config.project_id.clone(),
+            self.config.llm_config.clone(),
             self.config.socket_path.clone(),
             self.config.checkpoint_root.clone(),
         )?;
@@ -951,7 +952,7 @@ impl NewOrchestrator {
         let planner_output = plan_task_standard(
             prompt,
             &self.config.project_root,
-            &self.config.project_id,
+            &self.config.llm_config,
             dir_tree,
         )
         .await
@@ -996,7 +997,7 @@ impl NewOrchestrator {
             message: "Executing tasks (standard mode)...".into(),
         });
         let executor = Arc::new(AgentExecutor::new(
-            self.config.project_id.clone(),
+            self.config.llm_config.clone(),
             self.config.socket_path.clone(),
             self.config.checkpoint_root.clone(),
         )?);
@@ -1211,7 +1212,7 @@ impl NewOrchestrator {
             layer: 5,
             message: "Merging (standard mode)...".into(),
         });
-        let reviewer = MergeReviewerAgent::new(self.config.project_id.clone());
+        let reviewer = MergeReviewerAgent::new(self.config.llm_config.clone());
         let mut sandbox_results = HashMap::new();
 
         for (sandbox_name, agent_work_results) in &sandbox_agent_results {
@@ -1265,7 +1266,7 @@ impl NewOrchestrator {
             layer: 6,
             message: "Verifying (standard mode, 1 round)...".into(),
         });
-        let verification_loop = VerificationLoop::new(self.config.project_id.clone(), 1);
+        let verification_loop = VerificationLoop::new(self.config.llm_config.clone(), 1);
         let mut verification_status = HashMap::new();
 
         let executor_ref = &*executor;

--- a/agentd/src/orchestration/planner.rs
+++ b/agentd/src/orchestration/planner.rs
@@ -3,6 +3,7 @@
 //! Replaces old Context Gatherer (128 rounds) + Architect + Sandbox Owner
 //! with ONE LLM call that produces both task graph AND sandbox topology
 
+use super::provider_client::{generate_text, LlmConfig};
 use agentd_protocol::{SandboxTopology, TaskGraph, TaskId};
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -22,39 +23,32 @@ pub struct PlannerOutput {
 pub async fn plan_task(
     prompt: &str,
     project_root: &Path,
-    project_id: &str,
+    llm_config: &LlmConfig,
 ) -> Result<PlannerOutput> {
     log::info!("Starting fast planner:");
     log::info!("  Prompt: {}...", &prompt.chars().take(100).collect::<String>());
     log::info!("  Project root: {:?}", project_root);
-    log::info!("  Project ID: {}", project_id);
+    log::info!("  Provider: {}", llm_config.provider);
 
-    // Validate inputs
     if prompt.is_empty() {
         return Err(anyhow!("Planner: Prompt cannot be empty"));
     }
     std::fs::create_dir_all(project_root)
         .with_context(|| format!("Planner: Failed to create project root: {:?}", project_root))?;
-    if project_id.is_empty() {
-        return Err(anyhow!("Planner: Project ID cannot be empty"));
-    }
 
-    // Step 1: Shell scan to get directory tree
     log::info!("  Scanning directory tree...");
     let dir_tree = scan_directory_tree(project_root)
         .context("Failed to scan directory tree")?;
     log::info!("  Directory scan complete: {} bytes", dir_tree.len());
 
-    // Step 2: Single Gemini call with prompt + dir tree
-    log::info!("  Calling Gemini planner...");
-    let gemini_response = call_gemini_planner(prompt, &dir_tree, project_id)
+    log::info!("  Calling LLM planner...");
+    let llm_response = call_llm_planner(prompt, &dir_tree, llm_config)
         .await
-        .context("Gemini planner call failed")?;
-    log::info!("  Gemini call complete: {} bytes", gemini_response.len());
+        .context("LLM planner call failed")?;
+    log::info!("  LLM call complete: {} bytes", llm_response.len());
 
-    // Step 3: Parse response into task graph + topology
     log::info!("  Parsing planner response...");
-    let output = parse_planner_response(&gemini_response)
+    let output = parse_planner_response(&llm_response)
         .context("Failed to parse planner response")?;
     log::info!("  Planning complete!");
 
@@ -68,7 +62,7 @@ pub async fn plan_task(
 pub async fn plan_task_standard(
     prompt: &str,
     project_root: &Path,
-    project_id: &str,
+    llm_config: &LlmConfig,
     dir_tree: &str,
 ) -> Result<PlannerOutput> {
     log::info!("Standard planner (constrained):");
@@ -79,15 +73,12 @@ pub async fn plan_task_standard(
     }
     std::fs::create_dir_all(project_root)
         .with_context(|| format!("Planner: Failed to create project root: {:?}", project_root))?;
-    if project_id.is_empty() {
-        return Err(anyhow!("Planner: Project ID cannot be empty"));
-    }
 
-    let gemini_response = call_gemini_planner_standard(prompt, dir_tree, project_id)
+    let llm_response = call_llm_planner_standard(prompt, dir_tree, llm_config)
         .await
-        .context("Gemini standard planner call failed")?;
+        .context("LLM standard planner call failed")?;
 
-    let output = parse_planner_response(&gemini_response)
+    let output = parse_planner_response(&llm_response)
         .context("Failed to parse standard planner response")?;
 
     log::info!(
@@ -99,15 +90,12 @@ pub async fn plan_task_standard(
     Ok(output)
 }
 
-/// Constrained Gemini call for Standard mode: 1 sandbox, ≤ 3 agents, no cross-service.
-async fn call_gemini_planner_standard(
+/// Constrained LLM call for Standard mode: 1 sandbox, ≤ 3 agents, no cross-service.
+async fn call_llm_planner_standard(
     prompt: &str,
     dir_tree: &str,
-    project_id: &str,
+    llm_config: &LlmConfig,
 ) -> Result<String> {
-    let access_token = super::gcloud_access_token()?;
-    let url = super::vertex_generate_url(project_id);
-
     let system_prompt = r#"You are a fast task planner for an AI agent orchestration system operating in STANDARD mode.
 
 STANDARD MODE CONSTRAINTS (strictly enforced):
@@ -152,56 +140,15 @@ Output ONLY valid JSON in this exact format:
         prompt, dir_tree
     );
 
-    let request_body = serde_json::json!({
-        "contents": [
-            {
-                "role": "user",
-                "parts": [{"text": user_message}]
-            }
-        ],
-        "systemInstruction": {
-            "parts": [{"text": system_prompt}]
-        },
-        "generationConfig": super::vertex_generation_config_json(0.1)
-    });
-
-    let client = reqwest::Client::new();
-    let response = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {}", access_token))
-        .header("Content-Type", "application/json")
-        .json(&request_body)
-        .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS))
-        .send()
+    let text = generate_text(llm_config, system_prompt, &user_message, true, 0.1)
         .await
-        .context("Failed to send request to Gemini (standard planner)")?;
-
-    let status = response.status();
-    if !status.is_success() {
-        let error_text = response.text().await.unwrap_or_else(|_| "unknown error".to_string());
-        return Err(anyhow!("Gemini API error ({}): {}", status, error_text));
-    }
-
-    let response_json: serde_json::Value = response
-        .json()
-        .await
-        .context("Failed to parse Gemini response as JSON")?;
-
-    let text = response_json
-        .get("candidates")
-        .and_then(|c| c.get(0))
-        .and_then(|c| c.get("content"))
-        .and_then(|c| c.get("parts"))
-        .and_then(|p| p.get(0))
-        .and_then(|p| p.get("text"))
-        .and_then(|t| t.as_str())
-        .ok_or_else(|| anyhow!("Invalid Gemini response structure"))?;
+        .context("LLM standard planner call failed")?;
 
     if text.is_empty() {
-        return Err(anyhow!("Gemini returned empty response (standard planner)"));
+        return Err(anyhow!("LLM returned empty response (standard planner)"));
     }
 
-    Ok(text.to_string())
+    Ok(text)
 }
 
 /// Expose directory-tree scan so the orchestrator can reuse it for the
@@ -308,24 +255,18 @@ fn walk_dir_recursive(path: &Path, depth: usize, max_depth: usize, output: &mut 
     Ok(())
 }
 
-/// Call Gemini planner with prompt + directory tree
-async fn call_gemini_planner(
+/// Call LLM planner with prompt + directory tree (full mode).
+async fn call_llm_planner(
     prompt: &str,
     dir_tree: &str,
-    project_id: &str,
+    llm_config: &LlmConfig,
 ) -> Result<String> {
     if prompt.is_empty() {
         return Err(anyhow!("Empty prompt provided to planner"));
     }
-    if project_id.is_empty() {
-        return Err(anyhow!("Empty project_id provided to planner"));
-    }
     if dir_tree.is_empty() {
         return Err(anyhow!("Empty directory tree from scan"));
     }
-
-    let access_token = super::gcloud_access_token()?;
-    let url = super::vertex_generate_url(project_id);
 
     let system_prompt = r#"You are a fast task planner for an AI agent orchestration system.
 
@@ -380,57 +321,15 @@ Output ONLY valid JSON in this exact format:
         prompt, dir_tree
     );
 
-    let request_body = serde_json::json!({
-        "contents": [
-            {
-                "role": "user",
-                "parts": [{"text": user_message}]
-            }
-        ],
-        "systemInstruction": {
-            "parts": [{"text": system_prompt}]
-        },
-        "generationConfig": super::vertex_generation_config_json(0.1)
-    });
-
-    let client = reqwest::Client::new();
-    let response = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {}", access_token))
-        .header("Content-Type", "application/json")
-        .json(&request_body)
-        .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS))
-        .send()
+    let text = generate_text(llm_config, system_prompt, &user_message, true, 0.1)
         .await
-        .context("Failed to send request to Gemini")?;
-
-    let status = response.status();
-    if !status.is_success() {
-        let error_text = response.text().await.unwrap_or_else(|_| "unknown error".to_string());
-        return Err(anyhow!("Gemini API error ({}): {}", status, error_text));
-    }
-
-    let response_json: serde_json::Value = response
-        .json()
-        .await
-        .context("Failed to parse Gemini response as JSON")?;
-
-    // Extract text from response
-    let text = response_json
-        .get("candidates")
-        .and_then(|c| c.get(0))
-        .and_then(|c| c.get("content"))
-        .and_then(|c| c.get("parts"))
-        .and_then(|p| p.get(0))
-        .and_then(|p| p.get("text"))
-        .and_then(|t| t.as_str())
-        .ok_or_else(|| anyhow!("Invalid Gemini response structure: missing candidates/content/parts/text"))?;
+        .context("LLM planner call failed")?;
 
     if text.is_empty() {
-        return Err(anyhow!("Gemini returned empty response"));
+        return Err(anyhow!("LLM returned empty response (planner)"));
     }
 
-    Ok(text.to_string())
+    Ok(text)
 }
 
 /// Parse planner response into structured output

--- a/agentd/src/orchestration/provider_client.rs
+++ b/agentd/src/orchestration/provider_client.rs
@@ -1,0 +1,1026 @@
+//! Provider-agnostic LLM client for orchestration.
+//!
+//! Provides a unified interface over all supported AI providers:
+//! Vertex AI, Gemini (standalone API key), OpenAI, Grok, Groq, Anthropic.
+//!
+//! Two entry points:
+//! - `generate_text` — text/JSON completion (planner, merge reviewer, verification)
+//! - `call_agent_round` — one round of the tool-calling loop (agent execution)
+
+use crate::config::AiProvider;
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
+
+// ── LlmConfig ────────────────────────────────────────────────────────────────
+
+/// Provider credentials + model selection for a single orchestration run.
+#[derive(Debug, Clone)]
+pub struct LlmConfig {
+    pub provider: AiProvider,
+    pub model: String,
+    pub vertex_project_id: Option<String>,
+    pub api_key: Option<String>,
+}
+
+impl LlmConfig {
+    /// Build from the user's saved `MowisConfig`.
+    pub fn from_config(config: &crate::config::MowisConfig) -> Result<Self> {
+        match config.provider {
+            AiProvider::VertexAi => Ok(Self {
+                provider: AiProvider::VertexAi,
+                model: if config.model.is_empty() {
+                    "gemini-2.5-pro".into()
+                } else {
+                    config.model.clone()
+                },
+                vertex_project_id: Some(config.gcp_project_id.clone()),
+                api_key: None,
+            }),
+            AiProvider::Gemini => {
+                let api_key = config.gemini_api_key()?;
+                Ok(Self {
+                    provider: AiProvider::Gemini,
+                    model: if config.gemini_model.is_empty() {
+                        "gemini-2.5-pro".into()
+                    } else {
+                        config.gemini_model.clone()
+                    },
+                    vertex_project_id: None,
+                    api_key: Some(api_key),
+                })
+            }
+            AiProvider::OpenAi => {
+                let api_key = config.openai_api_key()?;
+                Ok(Self {
+                    provider: AiProvider::OpenAi,
+                    model: config.openai_model.clone(),
+                    vertex_project_id: None,
+                    api_key: Some(api_key),
+                })
+            }
+            AiProvider::Grok => {
+                let api_key = config.grok_api_key()?;
+                Ok(Self {
+                    provider: AiProvider::Grok,
+                    model: config.grok_model.clone(),
+                    vertex_project_id: None,
+                    api_key: Some(api_key),
+                })
+            }
+            AiProvider::Groq => {
+                let api_key = config.groq_api_key()?;
+                Ok(Self {
+                    provider: AiProvider::Groq,
+                    model: config.groq_model.clone(),
+                    vertex_project_id: None,
+                    api_key: Some(api_key),
+                })
+            }
+            AiProvider::Anthropic => {
+                let api_key = config.anthropic_api_key()?;
+                Ok(Self {
+                    provider: AiProvider::Anthropic,
+                    model: config.anthropic_model.clone(),
+                    vertex_project_id: None,
+                    api_key: Some(api_key),
+                })
+            }
+        }
+    }
+
+    /// Convenience constructor for Vertex AI from a project ID (CLI compat).
+    pub fn vertex(project_id: impl Into<String>) -> Self {
+        Self {
+            provider: AiProvider::VertexAi,
+            model: "gemini-2.5-pro".into(),
+            vertex_project_id: Some(project_id.into()),
+            api_key: None,
+        }
+    }
+}
+
+// ── Normalized Conversation ───────────────────────────────────────────────────
+
+/// A single tool call returned by the assistant.
+#[derive(Debug, Clone)]
+pub struct ToolCall {
+    /// Provider-specific call ID (used for OpenAI `tool_call_id` / Anthropic `tool_use_id`).
+    pub id: String,
+    pub name: String,
+    pub args: Value,
+}
+
+#[derive(Debug, Clone)]
+enum ConvMessage {
+    User(String),
+    AssistantText(String),
+    AssistantToolCalls(Vec<ToolCall>),
+    /// (call_id, tool_name, result_value) — one entry per tool call in the round.
+    ToolResults(Vec<(String, String, Value)>),
+}
+
+/// Provider-agnostic conversation history for the agent tool-calling loop.
+#[derive(Debug, Clone, Default)]
+pub struct AgentConversation {
+    messages: Vec<ConvMessage>,
+}
+
+impl AgentConversation {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push_user(&mut self, text: String) {
+        self.messages.push(ConvMessage::User(text));
+    }
+
+    /// Append all tool results from one round as a single conversation turn.
+    pub fn push_tool_results(&mut self, results: Vec<(ToolCall, Value)>) {
+        let normalized: Vec<(String, String, Value)> = results
+            .into_iter()
+            .map(|(tc, result)| (tc.id, tc.name, result))
+            .collect();
+        self.messages.push(ConvMessage::ToolResults(normalized));
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.messages.is_empty()
+    }
+}
+
+/// Output from a single agent round.
+pub struct AgentRoundResult {
+    pub text: Option<String>,
+    pub tool_calls: Vec<ToolCall>,
+}
+
+// ── Text Generation ───────────────────────────────────────────────────────────
+
+/// Generate a text (or JSON) completion — no tool calling.
+///
+/// Used by: planner, merge reviewer, verification planner, fix-task generator.
+pub async fn generate_text(
+    llm_config: &LlmConfig,
+    system_prompt: &str,
+    user_message: &str,
+    json_mode: bool,
+    temperature: f64,
+) -> Result<String> {
+    match llm_config.provider {
+        AiProvider::VertexAi | AiProvider::Gemini => {
+            generate_text_gemini(llm_config, system_prompt, user_message, json_mode, temperature)
+                .await
+        }
+        AiProvider::OpenAi | AiProvider::Grok | AiProvider::Groq => {
+            generate_text_openai_compat(
+                llm_config,
+                system_prompt,
+                user_message,
+                json_mode,
+                temperature,
+            )
+            .await
+        }
+        AiProvider::Anthropic => {
+            generate_text_anthropic(llm_config, system_prompt, user_message, temperature).await
+        }
+    }
+}
+
+async fn generate_text_gemini(
+    llm_config: &LlmConfig,
+    system_prompt: &str,
+    user_message: &str,
+    json_mode: bool,
+    temperature: f64,
+) -> Result<String> {
+    let (url, auth_header) = gemini_url_and_auth(llm_config)?;
+
+    let mut gen_config = json!({
+        "temperature": temperature,
+        "maxOutputTokens": super::VERTEX_MAX_OUTPUT_TOKENS,
+    });
+    if json_mode {
+        gen_config
+            .as_object_mut()
+            .unwrap()
+            .insert("responseMimeType".into(), json!("application/json"));
+    }
+    if super::VERTEX_THINKING_BUDGET_TOKENS > 0 {
+        gen_config.as_object_mut().unwrap().insert(
+            "thinkingConfig".into(),
+            json!({ "thinkingBudget": super::VERTEX_THINKING_BUDGET_TOKENS }),
+        );
+    }
+
+    let request_body = json!({
+        "contents": [{"role": "user", "parts": [{"text": user_message}]}],
+        "systemInstruction": {"parts": [{"text": system_prompt}]},
+        "generationConfig": gen_config
+    });
+
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .json(&request_body)
+        .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS));
+
+    if let Some(header) = auth_header {
+        req = req.header("Authorization", header);
+    }
+
+    let response = req
+        .send()
+        .await
+        .context("Gemini generate_text request failed")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!("Gemini API error ({}): {}", status, body));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .context("parse Gemini generate_text response")?;
+
+    extract_gemini_text(&resp_json)
+}
+
+async fn generate_text_openai_compat(
+    llm_config: &LlmConfig,
+    system_prompt: &str,
+    user_message: &str,
+    json_mode: bool,
+    temperature: f64,
+) -> Result<String> {
+    let url = openai_compat_url(llm_config);
+    let api_key = llm_config
+        .api_key
+        .as_deref()
+        .ok_or_else(|| anyhow!("No API key configured for {}", llm_config.provider))?;
+
+    let mut body = json!({
+        "model": llm_config.model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message}
+        ],
+        "temperature": temperature,
+        "max_tokens": 16384
+    });
+
+    if json_mode {
+        body.as_object_mut().unwrap().insert(
+            "response_format".into(),
+            json!({ "type": "json_object" }),
+        );
+    }
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS))
+        .send()
+        .await
+        .context("OpenAI-compat generate_text request failed")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "{} API error ({}): {}",
+            llm_config.provider,
+            status,
+            text
+        ));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .context("parse OpenAI-compat generate_text response")?;
+
+    resp_json
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"))
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .ok_or_else(|| {
+            anyhow!(
+                "{}: unexpected response structure in generate_text",
+                llm_config.provider
+            )
+        })
+        .map(|s| s.to_string())
+}
+
+async fn generate_text_anthropic(
+    llm_config: &LlmConfig,
+    system_prompt: &str,
+    user_message: &str,
+    temperature: f64,
+) -> Result<String> {
+    let api_key = llm_config
+        .api_key
+        .as_deref()
+        .ok_or_else(|| anyhow!("No Anthropic API key configured"))?;
+
+    let body = json!({
+        "model": llm_config.model,
+        "system": system_prompt,
+        "messages": [{"role": "user", "content": user_message}],
+        "max_tokens": 8192,
+        "temperature": temperature
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS))
+        .send()
+        .await
+        .context("Anthropic generate_text request failed")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(anyhow!("Anthropic API error ({}): {}", status, text));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .context("parse Anthropic generate_text response")?;
+
+    resp_json
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|b| {
+                b.get("type").and_then(|t| t.as_str()) == Some("text")
+            })
+        })
+        .and_then(|b| b.get("text"))
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| anyhow!("Anthropic: unexpected response structure in generate_text"))
+        .map(|s| s.to_string())
+}
+
+// ── Tool-calling loop ─────────────────────────────────────────────────────────
+
+/// Execute one round of the agent tool-calling loop.
+///
+/// Appends the assistant's response turn to `conversation`. Returns the tool
+/// calls to execute (empty vec = agent finished with a text reply). The caller
+/// executes the tools, then calls `conversation.push_tool_results()` before
+/// calling this function again for the next round.
+pub async fn call_agent_round(
+    llm_config: &LlmConfig,
+    system_prompt: &str,
+    conversation: &mut AgentConversation,
+    allowed_tools: &[String],
+    temperature: f64,
+) -> Result<AgentRoundResult> {
+    match llm_config.provider {
+        AiProvider::VertexAi | AiProvider::Gemini => {
+            call_agent_round_gemini(
+                llm_config,
+                system_prompt,
+                conversation,
+                allowed_tools,
+                temperature,
+            )
+            .await
+        }
+        AiProvider::OpenAi | AiProvider::Grok | AiProvider::Groq => {
+            call_agent_round_openai_compat(
+                llm_config,
+                system_prompt,
+                conversation,
+                allowed_tools,
+                temperature,
+            )
+            .await
+        }
+        AiProvider::Anthropic => {
+            call_agent_round_anthropic(
+                llm_config,
+                system_prompt,
+                conversation,
+                allowed_tools,
+                temperature,
+            )
+            .await
+        }
+    }
+}
+
+async fn call_agent_round_gemini(
+    llm_config: &LlmConfig,
+    system_prompt: &str,
+    conversation: &mut AgentConversation,
+    allowed_tools: &[String],
+    temperature: f64,
+) -> Result<AgentRoundResult> {
+    let (url, auth_header) = gemini_url_and_auth(llm_config)?;
+
+    let contents = conversation_to_gemini(conversation);
+    let tool_decls = build_gemini_tool_declarations(allowed_tools);
+
+    let mut gen_config = json!({
+        "temperature": temperature,
+        "maxOutputTokens": super::VERTEX_MAX_OUTPUT_TOKENS,
+    });
+    if super::VERTEX_THINKING_BUDGET_TOKENS > 0 {
+        gen_config.as_object_mut().unwrap().insert(
+            "thinkingConfig".into(),
+            json!({ "thinkingBudget": super::VERTEX_THINKING_BUDGET_TOKENS }),
+        );
+    }
+
+    let request_body = json!({
+        "contents": contents,
+        "systemInstruction": {"parts": [{"text": system_prompt}]},
+        "tools": [{"functionDeclarations": tool_decls}],
+        "generationConfig": gen_config
+    });
+
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .json(&request_body)
+        .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS));
+
+    if let Some(header) = auth_header {
+        req = req.header("Authorization", header);
+    }
+
+    let response = req
+        .send()
+        .await
+        .context("Gemini call_agent_round request failed")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!("Gemini API error ({}): {}", status, body));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .context("parse Gemini call_agent_round response")?;
+
+    let content = resp_json
+        .get("candidates")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("content"))
+        .ok_or_else(|| anyhow!("Gemini: no candidates in call_agent_round response"))?;
+
+    let parts = content
+        .get("parts")
+        .and_then(|p| p.as_array())
+        .ok_or_else(|| anyhow!("Gemini: no parts in call_agent_round response"))?;
+
+    let mut text: Option<String> = None;
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+
+    for part in parts {
+        if let Some(t) = part.get("text").and_then(|t| t.as_str()) {
+            if !t.is_empty() {
+                text = Some(t.to_string());
+            }
+        } else if let Some(fc) = part.get("functionCall") {
+            let name = fc
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("")
+                .to_string();
+            let args = fc.get("args").cloned().unwrap_or(json!({}));
+            let id = format!("call_{}", name);
+            tool_calls.push(ToolCall { id, name, args });
+        }
+    }
+
+    if tool_calls.is_empty() {
+        if let Some(ref t) = text {
+            conversation.messages.push(ConvMessage::AssistantText(t.clone()));
+        }
+    } else {
+        conversation
+            .messages
+            .push(ConvMessage::AssistantToolCalls(tool_calls.clone()));
+    }
+
+    Ok(AgentRoundResult { text, tool_calls })
+}
+
+async fn call_agent_round_openai_compat(
+    llm_config: &LlmConfig,
+    system_prompt: &str,
+    conversation: &mut AgentConversation,
+    allowed_tools: &[String],
+    temperature: f64,
+) -> Result<AgentRoundResult> {
+    let url = openai_compat_url(llm_config);
+    let api_key = llm_config
+        .api_key
+        .as_deref()
+        .ok_or_else(|| anyhow!("No API key for {}", llm_config.provider))?;
+
+    let messages = conversation_to_openai(conversation, system_prompt);
+    let tools = build_openai_tool_declarations(allowed_tools);
+
+    let body = json!({
+        "model": llm_config.model,
+        "messages": messages,
+        "tools": tools,
+        "tool_choice": "auto",
+        "temperature": temperature,
+        "max_tokens": 16384
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS))
+        .send()
+        .await
+        .context("OpenAI-compat call_agent_round request failed")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "{} API error ({}): {}",
+            llm_config.provider,
+            status,
+            text
+        ));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .context("parse OpenAI-compat call_agent_round response")?;
+
+    let message = resp_json
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"))
+        .ok_or_else(|| {
+            anyhow!(
+                "{}: no choices in call_agent_round response",
+                llm_config.provider
+            )
+        })?;
+
+    let text = message
+        .get("content")
+        .and_then(|c| c.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    let tool_calls: Vec<ToolCall> = message
+        .get("tool_calls")
+        .and_then(|tc| tc.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|tc| {
+                    let id = tc.get("id")?.as_str()?.to_string();
+                    let func = tc.get("function")?;
+                    let name = func.get("name")?.as_str()?.to_string();
+                    let args_str = func.get("arguments")?.as_str().unwrap_or("{}");
+                    let args = serde_json::from_str(args_str).unwrap_or(json!({}));
+                    Some(ToolCall { id, name, args })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if tool_calls.is_empty() {
+        if let Some(ref t) = text {
+            conversation
+                .messages
+                .push(ConvMessage::AssistantText(t.clone()));
+        }
+    } else {
+        conversation
+            .messages
+            .push(ConvMessage::AssistantToolCalls(tool_calls.clone()));
+    }
+
+    Ok(AgentRoundResult { text, tool_calls })
+}
+
+async fn call_agent_round_anthropic(
+    llm_config: &LlmConfig,
+    system_prompt: &str,
+    conversation: &mut AgentConversation,
+    allowed_tools: &[String],
+    temperature: f64,
+) -> Result<AgentRoundResult> {
+    let api_key = llm_config
+        .api_key
+        .as_deref()
+        .ok_or_else(|| anyhow!("No Anthropic API key configured"))?;
+
+    let messages = conversation_to_anthropic(conversation);
+    let tools = build_anthropic_tool_declarations(allowed_tools);
+
+    let body = json!({
+        "model": llm_config.model,
+        "system": system_prompt,
+        "messages": messages,
+        "tools": tools,
+        "max_tokens": 8192,
+        "temperature": temperature
+    });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .timeout(std::time::Duration::from_secs(super::HTTP_TIMEOUT_SECS))
+        .send()
+        .await
+        .context("Anthropic call_agent_round request failed")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(anyhow!("Anthropic API error ({}): {}", status, text));
+    }
+
+    let resp_json: Value = response
+        .json()
+        .await
+        .context("parse Anthropic call_agent_round response")?;
+
+    let content_blocks = resp_json
+        .get("content")
+        .and_then(|c| c.as_array())
+        .ok_or_else(|| anyhow!("Anthropic: no content in call_agent_round response"))?;
+
+    let mut text: Option<String> = None;
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+
+    for block in content_blocks {
+        match block.get("type").and_then(|t| t.as_str()) {
+            Some("text") => {
+                if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                    if !t.is_empty() {
+                        text = Some(t.to_string());
+                    }
+                }
+            }
+            Some("tool_use") => {
+                let id = block
+                    .get("id")
+                    .and_then(|i| i.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let name = block
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args = block.get("input").cloned().unwrap_or(json!({}));
+                tool_calls.push(ToolCall { id, name, args });
+            }
+            _ => {}
+        }
+    }
+
+    if tool_calls.is_empty() {
+        if let Some(ref t) = text {
+            conversation
+                .messages
+                .push(ConvMessage::AssistantText(t.clone()));
+        }
+    } else {
+        conversation
+            .messages
+            .push(ConvMessage::AssistantToolCalls(tool_calls.clone()));
+    }
+
+    Ok(AgentRoundResult { text, tool_calls })
+}
+
+// ── Conversation Serializers ──────────────────────────────────────────────────
+
+fn conversation_to_gemini(conv: &AgentConversation) -> Vec<Value> {
+    let mut result = Vec::new();
+    for msg in &conv.messages {
+        match msg {
+            ConvMessage::User(text) => {
+                result.push(json!({"role": "user", "parts": [{"text": text}]}));
+            }
+            ConvMessage::AssistantText(text) => {
+                result.push(json!({"role": "model", "parts": [{"text": text}]}));
+            }
+            ConvMessage::AssistantToolCalls(calls) => {
+                let parts: Vec<Value> = calls
+                    .iter()
+                    .map(|tc| json!({"functionCall": {"name": tc.name, "args": tc.args}}))
+                    .collect();
+                result.push(json!({"role": "model", "parts": parts}));
+            }
+            ConvMessage::ToolResults(results) => {
+                let parts: Vec<Value> = results
+                    .iter()
+                    .map(|(_, name, content)| {
+                        json!({"functionResponse": {"name": name, "response": content}})
+                    })
+                    .collect();
+                result.push(json!({"role": "function", "parts": parts}));
+            }
+        }
+    }
+    result
+}
+
+fn conversation_to_openai(conv: &AgentConversation, system_prompt: &str) -> Vec<Value> {
+    let mut result = vec![json!({"role": "system", "content": system_prompt})];
+    for msg in &conv.messages {
+        match msg {
+            ConvMessage::User(text) => {
+                result.push(json!({"role": "user", "content": text}));
+            }
+            ConvMessage::AssistantText(text) => {
+                result.push(json!({"role": "assistant", "content": text}));
+            }
+            ConvMessage::AssistantToolCalls(calls) => {
+                let tool_calls: Vec<Value> = calls
+                    .iter()
+                    .map(|tc| {
+                        json!({
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.name,
+                                "arguments": serde_json::to_string(&tc.args)
+                                    .unwrap_or_else(|_| "{}".into())
+                            }
+                        })
+                    })
+                    .collect();
+                result.push(
+                    json!({"role": "assistant", "content": null, "tool_calls": tool_calls}),
+                );
+            }
+            ConvMessage::ToolResults(results) => {
+                for (call_id, name, content) in results {
+                    result.push(json!({
+                        "role": "tool",
+                        "tool_call_id": call_id,
+                        "name": name,
+                        "content": serde_json::to_string(content)
+                            .unwrap_or_else(|_| "{}".into())
+                    }));
+                }
+            }
+        }
+    }
+    result
+}
+
+fn conversation_to_anthropic(conv: &AgentConversation) -> Vec<Value> {
+    let mut result = Vec::new();
+    for msg in &conv.messages {
+        match msg {
+            ConvMessage::User(text) => {
+                result.push(json!({"role": "user", "content": text}));
+            }
+            ConvMessage::AssistantText(text) => {
+                result.push(json!({"role": "assistant", "content": text}));
+            }
+            ConvMessage::AssistantToolCalls(calls) => {
+                let content: Vec<Value> = calls
+                    .iter()
+                    .map(|tc| {
+                        json!({"type": "tool_use", "id": tc.id, "name": tc.name, "input": tc.args})
+                    })
+                    .collect();
+                result.push(json!({"role": "assistant", "content": content}));
+            }
+            ConvMessage::ToolResults(results) => {
+                let content: Vec<Value> = results
+                    .iter()
+                    .map(|(call_id, _, content)| {
+                        json!({
+                            "type": "tool_result",
+                            "tool_use_id": call_id,
+                            "content": serde_json::to_string(content)
+                                .unwrap_or_else(|_| "{}".into())
+                        })
+                    })
+                    .collect();
+                // Anthropic tool results use the "user" role
+                result.push(json!({"role": "user", "content": content}));
+            }
+        }
+    }
+    result
+}
+
+// ── Tool Declaration Builders ─────────────────────────────────────────────────
+
+fn build_gemini_tool_declarations(allowed_tools: &[String]) -> Vec<Value> {
+    filter_tools_from_registry(allowed_tools)
+}
+
+fn build_openai_tool_declarations(allowed_tools: &[String]) -> Vec<Value> {
+    filter_tools_from_registry(allowed_tools)
+        .into_iter()
+        .map(|tool| {
+            json!({
+                "type": "function",
+                "function": {
+                    "name": tool.get("name").and_then(|n| n.as_str()).unwrap_or(""),
+                    "description": tool.get("description").and_then(|d| d.as_str()).unwrap_or(""),
+                    "parameters": tool.get("parameters")
+                        .cloned()
+                        .unwrap_or(json!({"type": "object", "properties": {}}))
+                }
+            })
+        })
+        .collect()
+}
+
+fn build_anthropic_tool_declarations(allowed_tools: &[String]) -> Vec<Value> {
+    filter_tools_from_registry(allowed_tools)
+        .into_iter()
+        .map(|tool| {
+            json!({
+                "name": tool.get("name").and_then(|n| n.as_str()).unwrap_or(""),
+                "description": tool.get("description").and_then(|d| d.as_str()).unwrap_or(""),
+                "input_schema": tool.get("parameters")
+                    .cloned()
+                    .unwrap_or(json!({"type": "object", "properties": {}}))
+            })
+        })
+        .collect()
+}
+
+fn filter_tools_from_registry(allowed_tools: &[String]) -> Vec<Value> {
+    let all_tools = super::gemini_tool_declarations();
+    let empty_vec = vec![];
+    let all_tools_array = all_tools.as_array().unwrap_or(&empty_vec);
+    all_tools_array
+        .iter()
+        .filter(|tool| {
+            tool.get("name")
+                .and_then(|n| n.as_str())
+                .map(|name| allowed_tools.iter().any(|t| t == name))
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect()
+}
+
+// ── URL + Auth Helpers ────────────────────────────────────────────────────────
+
+fn gemini_url_and_auth(llm_config: &LlmConfig) -> Result<(String, Option<String>)> {
+    match llm_config.provider {
+        AiProvider::VertexAi => {
+            let project_id = llm_config
+                .vertex_project_id
+                .as_deref()
+                .ok_or_else(|| anyhow!("Vertex AI: no GCP project ID configured"))?;
+            let token = super::gcloud_access_token()?;
+            let url = super::vertex_generate_url(project_id);
+            Ok((url, Some(format!("Bearer {}", token))))
+        }
+        AiProvider::Gemini => {
+            let api_key = llm_config
+                .api_key
+                .as_deref()
+                .ok_or_else(|| anyhow!("Gemini: no API key configured"))?;
+            let url = format!(
+                "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
+                llm_config.model, api_key
+            );
+            Ok((url, None))
+        }
+        _ => Err(anyhow!(
+            "gemini_url_and_auth called for non-Gemini provider: {}",
+            llm_config.provider
+        )),
+    }
+}
+
+fn openai_compat_url(llm_config: &LlmConfig) -> String {
+    match llm_config.provider {
+        AiProvider::OpenAi => "https://api.openai.com/v1/chat/completions".into(),
+        AiProvider::Grok => "https://api.x.ai/v1/chat/completions".into(),
+        AiProvider::Groq => "https://api.groq.com/openai/v1/chat/completions".into(),
+        _ => "https://api.openai.com/v1/chat/completions".into(),
+    }
+}
+
+// ── Response Parsing Helpers ──────────────────────────────────────────────────
+
+fn extract_gemini_text(resp_json: &Value) -> Result<String> {
+    resp_json
+        .get("candidates")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("content"))
+        .and_then(|c| c.get("parts"))
+        .and_then(|p| p.get(0))
+        .and_then(|p| p.get("text"))
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| anyhow!("Gemini: unexpected response structure (missing candidates[0].content.parts[0].text)"))
+        .map(|s| s.to_string())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_conversation_to_gemini_basic() {
+        let mut conv = AgentConversation::new();
+        conv.push_user("hello".into());
+        let gemini = conversation_to_gemini(&conv);
+        assert_eq!(gemini.len(), 1);
+        assert_eq!(gemini[0]["role"], "user");
+        assert_eq!(gemini[0]["parts"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn test_conversation_to_openai_includes_system() {
+        let mut conv = AgentConversation::new();
+        conv.push_user("task".into());
+        let msgs = conversation_to_openai(&conv, "you are an assistant");
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0]["role"], "system");
+        assert_eq!(msgs[1]["role"], "user");
+    }
+
+    #[test]
+    fn test_conversation_to_anthropic_tool_results_use_user_role() {
+        let mut conv = AgentConversation::new();
+        conv.push_user("do the thing".into());
+        conv.messages.push(ConvMessage::AssistantToolCalls(vec![ToolCall {
+            id: "c1".into(),
+            name: "read_file".into(),
+            args: json!({"path": "/workspace/foo.rs"}),
+        }]));
+        conv.push_tool_results(vec![(
+            ToolCall {
+                id: "c1".into(),
+                name: "read_file".into(),
+                args: json!({}),
+            },
+            json!({"content": "file content"}),
+        )]);
+        let msgs = conversation_to_anthropic(&conv);
+        // user, assistant (tool_use), user (tool_result)
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[2]["role"], "user");
+        assert_eq!(msgs[2]["content"][0]["type"], "tool_result");
+    }
+
+    #[test]
+    fn test_build_openai_tool_declarations_wraps_in_function() {
+        let tools = build_openai_tool_declarations(&["read_file".to_string()]);
+        assert!(!tools.is_empty());
+        assert_eq!(tools[0]["type"], "function");
+        assert!(tools[0]["function"]["name"].as_str().is_some());
+    }
+
+    #[test]
+    fn test_build_anthropic_tool_declarations_uses_input_schema() {
+        let tools = build_anthropic_tool_declarations(&["write_file".to_string()]);
+        assert!(!tools.is_empty());
+        assert!(tools[0].get("input_schema").is_some());
+    }
+
+    #[test]
+    fn test_llm_config_vertex_constructor() {
+        let cfg = LlmConfig::vertex("my-project");
+        assert!(matches!(cfg.provider, AiProvider::VertexAi));
+        assert_eq!(cfg.vertex_project_id.as_deref(), Some("my-project"));
+    }
+}

--- a/agentd/src/orchestration/verification.rs
+++ b/agentd/src/orchestration/verification.rs
@@ -8,6 +8,7 @@
 //! flaky verification.
 
 use super::agent_execution::AgentExecutor;
+use super::provider_client::{generate_text, LlmConfig};
 use super::sandbox_topology::TopologyManager;
 use agentd_protocol::{SandboxName, Task, TaskId, VerificationStatus};
 use anyhow::{anyhow, Context, Result};
@@ -71,16 +72,16 @@ pub struct VerificationResult {
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub struct VerificationPlanner {
-    project_id: String,
+    llm_config: LlmConfig,
     pub max_rounds: usize,
     /// Per-VF execution timeout in seconds
     pub max_test_execution_time: u64,
 }
 
 impl VerificationPlanner {
-    pub fn new(project_id: String, max_rounds: usize) -> Self {
+    pub fn new(llm_config: LlmConfig, max_rounds: usize) -> Self {
         Self {
-            project_id,
+            llm_config,
             max_rounds,
             max_test_execution_time: 60,
         }
@@ -96,9 +97,6 @@ impl VerificationPlanner {
         merged_diff: &str,
         original_tasks: &[Task],
     ) -> Result<VerificationPlan> {
-        let access_token = super::gcloud_access_token()?;
-        let url = super::vertex_generate_url(&self.project_id);
-
         // CRITICAL: The system prompt asks for DETERMINISTIC shell commands,
         // not vague descriptions. This is what makes VFs stable across rounds.
         let system_prompt = r#"You are a verification function planner for a multi-agent code execution system.
@@ -154,51 +152,11 @@ Standard VF set (adapt to detected toolchain):
             sandbox_name, task_summaries, merged_diff
         );
 
-        let request_body = json!({
-            "contents": [
-                {
-                    "role": "user",
-                    "parts": [{"text": user_message}]
-                }
-            ],
-            "systemInstruction": {
-                "parts": [{"text": system_prompt}]
-            },
-            "generationConfig": super::vertex_generation_config_json(0.1)
-        });
-
-        let client = reqwest::Client::new();
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", access_token))
-            .header("Content-Type", "application/json")
-            .json(&request_body)
-            .timeout(std::time::Duration::from_secs(60))
-            .send()
+        let text = generate_text(&self.llm_config, system_prompt, &user_message, true, 0.1)
             .await
-            .context("Failed to send VF planning request")?;
+            .context("LLM VF planning request failed")?;
 
-        if !response.status().is_success() {
-            let error_text = response.text().await.unwrap_or_default();
-            return Err(anyhow!("Gemini API error during VF planning: {}", error_text));
-        }
-
-        let response_json: serde_json::Value = response
-            .json()
-            .await
-            .context("Failed to parse VF planning response")?;
-
-        let text = response_json
-            .get("candidates")
-            .and_then(|c| c.get(0))
-            .and_then(|c| c.get("content"))
-            .and_then(|c| c.get("parts"))
-            .and_then(|p| p.get(0))
-            .and_then(|p| p.get("text"))
-            .and_then(|t| t.as_str())
-            .ok_or_else(|| anyhow!("Invalid VF planning response structure"))?;
-
-        let json_str = extract_json(text);
+        let json_str = extract_json(&text);
 
         #[derive(Deserialize)]
         struct VfPlanJson {
@@ -232,9 +190,6 @@ Standard VF set (adapt to detected toolchain):
         vf_command: &str,
         failure_output: &str,
     ) -> Result<Vec<Task>> {
-        let access_token = super::gcloud_access_token()?;
-        let url = super::vertex_generate_url(&self.project_id);
-
         let system_prompt = r#"You are a test failure analyzer. Given a failed verification command and its output, generate fix tasks.
 
 Output JSON in this format:
@@ -252,50 +207,14 @@ Each fix task must be specific, actionable, and directly address the failure out
             failed_vf_id, vf_command, failure_output
         );
 
-        let request_body = json!({
-            "contents": [
-                {
-                    "role": "user",
-                    "parts": [{"text": user_message}]
-                }
-            ],
-            "systemInstruction": {
-                "parts": [{"text": system_prompt}]
-            },
-            "generationConfig": super::vertex_generation_config_json(0.3)
-        });
-
-        let client = reqwest::Client::new();
-        let response = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", access_token))
-            .header("Content-Type", "application/json")
-            .json(&request_body)
-            .timeout(std::time::Duration::from_secs(60))
-            .send()
+        let text = match generate_text(&self.llm_config, system_prompt, &user_message, true, 0.3)
             .await
-            .context("Failed to send fix task request")?;
+        {
+            Ok(t) => t,
+            Err(_) => return Ok(vec![]),
+        };
 
-        if !response.status().is_success() {
-            return Ok(vec![]);
-        }
-
-        let response_json: serde_json::Value = response
-            .json()
-            .await
-            .context("Failed to parse fix task response")?;
-
-        let text = response_json
-            .get("candidates")
-            .and_then(|c| c.get(0))
-            .and_then(|c| c.get("content"))
-            .and_then(|c| c.get("parts"))
-            .and_then(|p| p.get(0))
-            .and_then(|p| p.get("text"))
-            .and_then(|t| t.as_str())
-            .ok_or_else(|| anyhow!("Invalid fix task response structure"))?;
-
-        let json_str = extract_json(text);
+        let json_str = extract_json(&text);
 
         #[derive(Deserialize)]
         struct FixTasksJson {
@@ -328,9 +247,9 @@ pub struct VerificationLoop {
 }
 
 impl VerificationLoop {
-    pub fn new(project_id: String, max_rounds: usize) -> Self {
+    pub fn new(llm_config: LlmConfig, max_rounds: usize) -> Self {
         Self {
-            planner: VerificationPlanner::new(project_id.clone(), max_rounds),
+            planner: VerificationPlanner::new(llm_config, max_rounds),
             max_rounds,
         }
     }
@@ -946,13 +865,19 @@ These VFs cover the main implementation."#;
 
     #[test]
     fn test_with_test_timeout_sets_value() {
-        let vl = VerificationLoop::new("proj".to_string(), 3).with_test_timeout(120);
+        let vl = VerificationLoop::new(
+            super::provider_client::LlmConfig::vertex("proj"),
+            3,
+        ).with_test_timeout(120);
         assert_eq!(vl.planner.max_test_execution_time, 120);
     }
 
     #[test]
     fn test_default_timeout_is_60s() {
-        let vl = VerificationLoop::new("proj".to_string(), 3);
+        let vl = VerificationLoop::new(
+            super::provider_client::LlmConfig::vertex("proj"),
+            3,
+        );
         assert_eq!(vl.planner.max_test_execution_time, 60);
     }
 
@@ -960,7 +885,10 @@ These VFs cover the main implementation."#;
 
     #[test]
     fn test_planner_new_defaults() {
-        let p = VerificationPlanner::new("test-project".to_string(), 5);
+        let p = VerificationPlanner::new(
+            super::provider_client::LlmConfig::vertex("test-project"),
+            5,
+        );
         assert_eq!(p.max_test_execution_time, 60);
         assert_eq!(p.max_rounds, 5);
     }

--- a/agentd/src/tui/app.rs
+++ b/agentd/src/tui/app.rs
@@ -1034,8 +1034,10 @@ impl App {
                 let (orch_event_tx, orch_event_rx) = std::sync::mpsc::channel();
 
                 let project_root = std::env::current_dir().unwrap_or_default();
+                let llm_config = crate::orchestration::provider_client::LlmConfig::from_config(&config)
+                    .unwrap_or_else(|_| crate::orchestration::provider_client::LlmConfig::vertex(&config.gcp_project_id));
                 let orch_config = crate::orchestration::OrchestratorConfig {
-                    project_id: config.gcp_project_id.clone(),
+                    llm_config,
                     socket_path: config.socket_path.clone(),
                     project_root,
                     overlay_root: std::path::PathBuf::from(&config.overlay_root),


### PR DESCRIPTION
## Summary

- Introduces `provider_client.rs` as a unified LLM abstraction layer so the coding agent (planner, agent execution, merge reviewer, verification) works with all six supported providers — VertexAi, Gemini, Anthropic, OpenAI, Grok, Groq — instead of being hardcoded to Vertex AI
- `LlmConfig` + `generate_text()` + `call_agent_round()` replace all direct Vertex AI / gcloud calls across the orchestration pipeline
- `AgentConversation` normalises conversation history internally and serialises to the correct wire format per provider on each call (Gemini/Vertex, OpenAI-compatible, Anthropic)
- `OrchestratorConfig.project_id` replaced by `llm_config: LlmConfig`; `tui/app.rs` and `main.rs` build `LlmConfig` from saved `MowisConfig`, falling back to Vertex AI with `--project` flag for backward compatibility

## Files changed

| File | Change |
|------|--------|
| `agentd/src/orchestration/provider_client.rs` | **New** — central provider abstraction |
| `agentd/src/orchestration/planner.rs` | Use `LlmConfig` instead of project ID |
| `agentd/src/orchestration/agent_execution.rs` | Use `AgentConversation` + `call_agent_round()` |
| `agentd/src/orchestration/merge_reviewer.rs` | Use `generate_text()` |
| `agentd/src/orchestration/verification.rs` | Use `generate_text()` |
| `agentd/src/orchestration/new_orchestrator.rs` | `project_id` → `llm_config` in `OrchestratorConfig` |
| `agentd/src/orchestration/mod.rs` | Export `provider_client` module |
| `agentd/src/tui/app.rs` | Build `LlmConfig` from `MowisConfig` |
| `agentd/src/main.rs` | Build `LlmConfig` from `MowisConfig`; `--project` as Vertex fallback |

## Test plan

- [ ] `cargo build` compiles without errors
- [ ] Existing 67 tests pass (`cargo test`)
- [ ] TUI orchestration works with Anthropic provider configured
- [ ] TUI orchestration works with OpenAI provider configured
- [ ] TUI orchestration works with Vertex AI provider (backward compat via `--project` flag)
- [ ] CLI `orchestrate` command works with saved `MowisConfig`

https://claude.ai/code/session_016LH2g54xgsRmUBEQyZNbE1

---
_Generated by [Claude Code](https://claude.ai/code/session_016LH2g54xgsRmUBEQyZNbE1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-provider LLM support now available: OpenAI, Anthropic, Vertex AI, Grok, and Groq.
  * Enhanced configuration system with flexible provider and model selection.

* **Refactor**
  * Agent execution, planning, merge review, and verification processes updated to support multiple LLM providers through a unified orchestration interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->