### PR TITLE
fix: update stale model IDs and patch Anthropic json_mode

### DIFF
--- a/agentd/src/orchestration/provider_client.rs
+++ b/agentd/src/orchestration/provider_client.rs
@@ -182,7 +182,7 @@ pub async fn generate_text(
             .await
         }
         AiProvider::Anthropic => {
-            generate_text_anthropic(llm_config, system_prompt, user_message, temperature).await
+            generate_text_anthropic(llm_config, system_prompt, user_message, json_mode, temperature).await
         }
     }
 }
@@ -325,6 +325,7 @@ async fn generate_text_anthropic(
     llm_config: &LlmConfig,
     system_prompt: &str,
     user_message: &str,
+    json_mode: bool,
     temperature: f64,
 ) -> Result<String> {
     let api_key = llm_config
@@ -332,10 +333,21 @@ async fn generate_text_anthropic(
         .as_deref()
         .ok_or_else(|| anyhow!("No Anthropic API key configured"))?;
 
+    // Anthropic has no native json_mode — use assistant prefill with "{" to
+    // force the model to begin a JSON object, guaranteeing parseable output.
+    let messages = if json_mode {
+        json!([
+            {"role": "user", "content": user_message},
+            {"role": "assistant", "content": "{"}
+        ])
+    } else {
+        json!([{"role": "user", "content": user_message}])
+    };
+
     let body = json!({
         "model": llm_config.model,
         "system": system_prompt,
-        "messages": [{"role": "user", "content": user_message}],
+        "messages": messages,
         "max_tokens": 8192,
         "temperature": temperature
     });
@@ -363,7 +375,7 @@ async fn generate_text_anthropic(
         .await
         .context("parse Anthropic generate_text response")?;
 
-    resp_json
+    let text = resp_json
         .get("content")
         .and_then(|c| c.as_array())
         .and_then(|arr| {
@@ -373,8 +385,14 @@ async fn generate_text_anthropic(
         })
         .and_then(|b| b.get("text"))
         .and_then(|t| t.as_str())
-        .ok_or_else(|| anyhow!("Anthropic: unexpected response structure in generate_text"))
-        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("Anthropic: unexpected response structure in generate_text"))?;
+
+    // When json_mode prefill was used the model continues from "{", so restore it.
+    if json_mode {
+        Ok(format!("{{{}", text))
+    } else {
+        Ok(text.to_string())
+    }
 }
 
 // ── Tool-calling loop ─────────────────────────────────────────────────────────

--- a/agentd/src/setup.rs
+++ b/agentd/src/setup.rs
@@ -46,9 +46,9 @@ struct ModelOption {
 }
 
 const ANTHROPIC_MODELS: &[ModelOption] = &[
-    ModelOption { id: "claude-3-7-sonnet-20250219", label: "Claude 3.7 Sonnet", note: "Hybrid reasoning + tools" },
-    ModelOption { id: "claude-3-5-sonnet-20241022", label: "Claude 3.5 Sonnet", note: "Fast and reliable"        },
-    ModelOption { id: "claude-3-5-haiku-20241022",  label: "Claude 3.5 Haiku",  note: "Blazing fast"             },
+    ModelOption { id: "claude-opus-4-7",           label: "Claude Opus 4.7",   note: "Most capable — complex tasks"  },
+    ModelOption { id: "claude-sonnet-4-6",         label: "Claude Sonnet 4.6", note: "Smart + fast, 1M context"      },
+    ModelOption { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5",  note: "Fast, cost-efficient"          },
 ];
 
 const OPENAI_MODELS: &[ModelOption] = &[
@@ -59,9 +59,9 @@ const OPENAI_MODELS: &[ModelOption] = &[
 ];
 
 const GEMINI_MODELS: &[ModelOption] = &[
-    ModelOption { id: "gemini-2.0-flash",           label: "Gemini 2.0 Flash",      note: "Next-gen speed"           },
-    ModelOption { id: "gemini-2.0-pro-exp-02-05",    label: "Gemini 2.0 Pro (Exp)",  note: "High reasoning"           },
-    ModelOption { id: "gemini-1.5-pro",             label: "Gemini 1.5 Pro",        note: "Large context"            },
+    ModelOption { id: "gemini-2.5-pro",        label: "Gemini 2.5 Pro",        note: "Frontier — highest quality"  },
+    ModelOption { id: "gemini-2.5-flash",      label: "Gemini 2.5 Flash",      note: "Fast, balanced"              },
+    ModelOption { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash-Lite", note: "Lightweight, cost-efficient" },
 ];
 
 // ── Public API ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up fixes to PR #46 (provider-agnostic orchestration), addressing two issues flagged during review:

- **Anthropic `json_mode` bug** — `generate_text_anthropic` was ignoring the `json_mode` parameter, causing planner/merge-reviewer/verification to receive free-form text instead of JSON when using Anthropic, breaking JSON parsing downstream. Fixed by adding an assistant prefill `{"role": "assistant", "content": "{"}` when `json_mode: true`, which forces the model to open a JSON object. The leading `{` is prepended back onto the response string so callers receive a complete parseable result.

- **Stale Gemini model IDs** — All three models in the setup wizard were deprecated/dead (`gemini-2.0-flash`, `gemini-2.0-pro-exp-02-05`, `gemini-1.5-pro`). Replaced with the current 2.5 generation.

- **Stale Anthropic model IDs** — Setup wizard offered `claude-3-7-sonnet`, `claude-3-5-sonnet`, `claude-3-5-haiku`, all superseded. Replaced with current `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`.

## Files changed

| File | Change |
|------|--------|
| `agentd/src/orchestration/provider_client.rs` | Add `json_mode` param to `generate_text_anthropic`; implement prefill + response restoration |
| `agentd/src/setup.rs` | Update Gemini models → 2.5 generation; update Anthropic models → Claude 4.x family |

## Updated model lists

### Gemini (via setup wizard)
| Before | After |
|--------|-------|
| `gemini-2.0-flash` | `gemini-2.5-flash` |
| `gemini-2.0-pro-exp-02-05` | `gemini-2.5-pro` |
| `gemini-1.5-pro` | `gemini-2.5-flash-lite` |

### Anthropic (via setup wizard)
| Before | After |
|--------|-------|
| `claude-3-7-sonnet-20250219` | `claude-opus-4-7` |
| `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |
| `claude-3-5-haiku-20241022` | `claude-haiku-4-5-20251001` |

## Test plan

- [ ] `cargo build` compiles without errors
- [ ] Planner works correctly with Anthropic provider (JSON parsed successfully)
- [ ] Setup wizard shows correct Gemini 2.5 model options
- [ ] Setup wizard shows correct Claude 4.x model options

https://claude.ai/code/session_016LH2g54xgsRmUBEQyZNbE1

---
_Generated by [Claude Code](https://claude.ai/code/session_016LH2g54xgsRmUBEQyZNbE1)_