### PR TITLE
Add MowisAI Tauri desktop scaffold (UI, assets, and Rust backend command)

### DIFF
--- a/mowis-desktop/index.html
+++ b/mowis-desktop/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MowisAI Desktop</title>
+    <link rel="stylesheet" href="src/styles.css" />
+  </head>
+  <body>
+    <div id="app" class="mw-app">
+      <header class="mw-titlebar">
+        <div class="mw-traffic"><span></span><span></span><span></span></div>
+        <div class="mw-titlebar-center">
+          <span>MowisAI</span><span class="sep">/</span><span id="screen-label">Session</span><span class="sep">/</span><span id="session-label" style="font-style: italic;">feature/auth-refactor</span>
+        </div>
+        <div class="mw-titlebar-right"><span><i class="mw-status-dot"></i><span id="daemon-status">DAEMON</span></span><span id="build-version">v0.1.0</span></div>
+      </header>
+
+      <div class="mw-body">
+        <aside class="mw-sidebar">
+          <div class="mw-brand">Mowis<span style="font-style:italic">AI</span><span class="dot"></span></div>
+          <div class="mw-section-label">Workspace</div>
+          <div class="mw-nav-item" data-screen="welcome">Welcome <span class="badge">⌘0</span></div>
+          <div class="mw-nav-item" data-screen="home">Home <span class="badge">⌘1</span></div>
+          <div class="mw-nav-item active" data-screen="session">Active session <span class="badge">⌘2</span></div>
+          <div class="mw-nav-item" data-screen="agent">Agent detail <span class="badge">⌘3</span></div>
+          <div class="mw-nav-item" data-screen="sandboxes">Sandboxes <span class="badge">⌘4</span></div>
+          <div class="mw-nav-item" data-screen="timeline">Timeline <span class="badge">⌘5</span></div>
+          <div class="mw-nav-item" data-screen="settings">Settings <span class="badge">⌘6</span></div>
+          <div class="mw-sidebar-spacer"></div>
+          <div class="mw-sidebar-foot">you@mowis.ai<br/>Pro · 320h</div>
+        </aside>
+
+        <main class="mw-main" id="main-content"></main>
+
+        <aside class="mw-agents">
+          <div class="mw-agents-head">
+            <div class="title"><span style="font-style: italic;">Agents</span><span id="agent-ratio" style="font-family:var(--mono);font-size:10px;color:var(--tx-3)"></span></div>
+            <div class="meta">Fleet · live</div>
+            <div class="count-row"><span class="count" id="running-count">0</span><span class="count-label">Running now</span></div>
+          </div>
+          <div class="mw-agent-grid" id="agent-grid"></div>
+        </aside>
+      </div>
+
+      <div class="mw-statusbar" id="statusbar"></div>
+    </div>
+
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/mowis-desktop/package.json
+++ b/mowis-desktop/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mowis-desktop",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.4.11"
+  }
+}

--- a/mowis-desktop/src-tauri/Cargo.toml
+++ b/mowis-desktop/src-tauri/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mowis-desktop"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+tauri = { version = "2", features = [] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[features]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]
+
+[workspace]

--- a/mowis-desktop/src-tauri/build.rs
+++ b/mowis-desktop/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/mowis-desktop/src-tauri/src/main.rs
+++ b/mowis-desktop/src-tauri/src/main.rs
@@ -1,0 +1,26 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct AppHealth {
+    version: &'static str,
+    daemon_connected: bool,
+    tokens_per_hour: &'static str,
+}
+
+#[tauri::command]
+fn app_health() -> AppHealth {
+    AppHealth {
+        version: env!("CARGO_PKG_VERSION"),
+        daemon_connected: true,
+        tokens_per_hour: "184k",
+    }
+}
+
+fn main() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![app_health])
+        .run(tauri::generate_context!())
+        .expect("error while running mowis-desktop");
+}

--- a/mowis-desktop/src-tauri/tauri.conf.json
+++ b/mowis-desktop/src-tauri/tauri.conf.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "MowisAI Desktop",
+  "version": "0.1.0",
+  "identifier": "ai.mowis.desktop",
+  "build": {
+    "frontendDist": ".."
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "MowisAI Desktop",
+        "width": 1280,
+        "height": 800,
+        "resizable": true
+      }
+    ]
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": []
+  }
+}

--- a/mowis-desktop/src/main.js
+++ b/mowis-desktop/src/main.js
@@ -1,0 +1,249 @@
+const AGENTS = [
+  { id: 'a01', name: 'planner', task: 'Decomposing auth refactor into parallel workstreams.', sandbox: 'planner', status: 'running', step: '3 of 8', runtime: '00:14:22' },
+  { id: 'a02', name: 'auth-1', task: 'Replacing legacy session middleware with rotating tokens.', sandbox: 'backend-α', status: 'running', step: '2 of 5', runtime: '00:08:11' },
+  { id: 'a03', name: 'auth-2', task: 'Migrating user model for MFA enrollment.', sandbox: 'backend-β', status: 'running', step: '1 of 4', runtime: '00:03:42' },
+  { id: 'a04', name: 'auth-3', task: 'Rewriting password hash to argon2id.', sandbox: 'backend-γ', status: 'running', step: '4 of 6', runtime: '00:11:08' },
+  { id: 'a05', name: 'fe-login', task: 'Recomposing login form with new validation.', sandbox: 'frontend', status: 'running', step: '2 of 3', runtime: '00:06:55' },
+  { id: 'a06', name: 'fe-2fa', task: 'Building OTP entry and fallback flow.', sandbox: 'frontend', status: 'running', step: '1 of 4', runtime: '00:02:18' },
+  { id: 'a07', name: 'tests-unit', task: 'Generating unit tests for new session boundary.', sandbox: 'ci-α', status: 'running', step: '5 of 9', runtime: '00:18:00' },
+  { id: 'a08', name: 'tests-int', task: 'Drafting integration tests across services.', sandbox: 'ci-β', status: 'running', step: '3 of 7', runtime: '00:12:30' },
+  { id: 'a09', name: 'docs', task: 'Updating API reference for new endpoints.', sandbox: 'docs', status: 'running', step: '2 of 3', runtime: '00:04:11' },
+  { id: 'a10', name: 'mig-db', task: 'Writing reversible migration for users table.', sandbox: 'db', status: 'running', step: '1 of 2', runtime: '00:01:42' },
+  { id: 'a11', name: 'review-1', task: 'Reading diffs for security regressions.', sandbox: 'review', status: 'running', step: '—', runtime: '00:00:48' },
+  { id: 'a12', name: 'review-2', task: 'Cross-checking naming consistency.', sandbox: 'review', status: 'running', step: '—', runtime: '00:00:32' },
+  { id: 'b01', name: 'pool-1', task: 'Idle. Waiting for dispatch.', sandbox: 'pool', status: 'idle' },
+  { id: 'b02', name: 'pool-2', task: 'Idle. Waiting for dispatch.', sandbox: 'pool', status: 'idle' },
+  { id: 'c01', name: 'lint', task: 'Done — formatted backend module.', sandbox: 'ci-α', status: 'done' },
+  { id: 'c02', name: 'audit', task: 'Done — license audit clean.', sandbox: 'review', status: 'done' }
+];
+
+const appState = {
+  screen: 'session',
+  sessionName: 'feature/auth-refactor',
+  tasks: 8,
+  sandboxes: 6,
+  tokensPerHour: '184k',
+  daemonConnected: true
+};
+
+const main = document.getElementById('main-content');
+const grid = document.getElementById('agent-grid');
+const statusbar = document.getElementById('statusbar');
+
+function renderAgents() {
+  const running = AGENTS.filter((a) => a.status === 'running');
+  document.getElementById('running-count').textContent = running.length;
+  document.getElementById('agent-ratio').textContent = `${running.length}/${AGENTS.length}`;
+
+  grid.innerHTML = '';
+  AGENTS.slice(0, 16).forEach((agent) => {
+    const tile = document.createElement('div');
+    tile.className = `mw-agent-tile ${agent.status}`;
+    tile.innerHTML = `<span class="id">${agent.id}</span>`;
+
+    const pop = document.createElement('div');
+    pop.className = 'mw-agent-pop';
+    pop.innerHTML = `
+      <div class="name">${agent.id.toUpperCase()} · ${agent.name}</div>
+      <div class="task">${agent.task}</div>
+      <div class="row"><span>Sandbox</span><b>${agent.sandbox}</b></div>
+      <div class="row"><span>Step</span><b>${agent.step || '—'}</b></div>
+      <div class="row"><span>Status</span><b>${agent.status}</b></div>
+      ${agent.runtime ? `<div class="row"><span>Running</span><b>${agent.runtime}</b></div>` : ''}
+    `;
+
+    tile.addEventListener('mouseenter', () => tile.appendChild(pop));
+    tile.addEventListener('mouseleave', () => pop.remove());
+    tile.addEventListener('click', () => {
+      appState.screen = 'agent';
+      setActiveNav('agent');
+      renderScreen();
+    });
+
+    grid.appendChild(tile);
+  });
+}
+
+function renderStatusBar() {
+  statusbar.innerHTML = `
+    <span><span class="mw-status-dot" style="margin-right:8px"></span><b>${appState.daemonConnected ? 'Connected' : 'Disconnected'}</b></span>
+    <span class="sep">·</span>
+    <span><b>${AGENTS.filter((a) => a.status === 'running').length}</b> agents running</span>
+    <span class="sep">·</span>
+    <span><b>${appState.sandboxes}</b> sandboxes</span>
+    <span class="sep">·</span>
+    <span><b>${appState.tokensPerHour}</b> tokens / hr</span>
+    <span style="margin-left:auto">main · clean · ⌘K</span>
+  `;
+}
+
+function templateWelcome() {
+  return `<div class="mw-welcome" style="height:100%"><div class="word" style="filter: blur(2px)">Welcome to MowisAI</div><div class="continue"><button id="continue-btn">continue</button></div></div>`;
+}
+
+function templateHome() {
+  return `
+    <div class="mw-spawn">
+      <div class="mw-section-label" style="padding:0;margin:0">A new task</div>
+      <h1 style="font-style:italic">What should we work on?</h1>
+      <div class="lede">Describe a goal and MowisAI will decompose work across sandboxes and agents.</div>
+      <div class="mw-spawn-input">
+        <textarea id="task-input" placeholder="Refactor authentication layer, add MFA, update docs and tests."></textarea>
+        <div class="controls">
+          <span style="font-family:var(--sans);font-size:10px;color:var(--tx-3);letter-spacing:.08em;text-transform:uppercase">Repo · mowis/api</span>
+          <span style="font-family:var(--sans);font-size:10px;color:var(--tx-3);letter-spacing:.08em;text-transform:uppercase">Branch · main</span>
+          <span style="flex:1"></span>
+          <button class="mw-btn ghost">Plan first</button>
+          <button class="mw-btn primary" id="run-task">↩</button>
+        </div>
+      </div>
+    </div>`;
+}
+
+function templateSession() {
+  return `
+    <div class="mw-chat">
+      <div class="turn"><div class="role">You · 14:08</div><div class="body">Refactor authentication for MFA and rotating tokens. Keep tests green and docs updated.</div></div>
+      <div class="system"><span class="tag">PLAN</span><span>Planner created 8 tasks · 6 sandboxes · 12 agents dispatched</span></div>
+      <div class="turn"><div class="role">Planner · 14:09</div><div class="body muted">Three tracks run in parallel first: token middleware, hash migration, OTP UI. Dependencies auto-unblock via scheduler.</div></div>
+      <div class="system"><span class="tag">DISPATCH</span><span>auth-1 auth-2 auth-3 → backend · fe-login fe-2fa → frontend · mig-db → db</span></div>
+      <div class="turn"><div class="role">auth-1 · 14:14</div><div class="body">Token rotation middleware complete. Asking whether to enforce per-device revocation now or in follow-up.</div></div>
+      <div class="mw-composer">
+        <textarea placeholder="Type instructions to the fleet..."></textarea>
+        <div class="controls">
+          <span class="chip">Planner</span><span class="chip">Broadcast</span><span class="chip">Checkpoint every tool call</span>
+          <span style="flex:1"></span>
+          <button class="mw-btn ghost">Pause</button><button class="mw-btn primary">Send</button>
+        </div>
+      </div>
+    </div>`;
+}
+
+function templateAgentDetail() {
+  const a = AGENTS[1];
+  return `
+    <div class="mw-page-head"><div><div class="kicker">Agent ${a.id}</div><h1>${a.name}</h1></div><div class="mw-btn ghost">Reassign</div></div>
+    <div class="mw-page-body">
+      <div class="mw-grid-2">
+        <div class="mw-card"><div class="kicker">Task</div><p>${a.task}</p></div>
+        <div class="mw-card"><div class="kicker">Runtime</div><p>${a.runtime}</p><div class="kicker">Step ${a.step}</div></div>
+      </div>
+      <div class="mw-code">diff --git a/auth.rs b/auth.rs\n+ rotate_token(req.user_id);\n+ write_audit_log("token rotated");\n- legacy_session_extend();</div>
+    </div>`;
+}
+
+function templateSandboxes() {
+  return `
+    <div class="mw-page-head"><div><div class="kicker">Execution</div><h1>Sandboxes</h1></div><button class="mw-btn primary">+ New sandbox</button></div>
+    <div class="mw-page-body">
+      <div class="mw-grid-3">
+        <article class="mw-card"><div class="kicker">backend-α</div><h3>Rust API</h3><p>4 agents · running</p></article>
+        <article class="mw-card"><div class="kicker">frontend</div><h3>Tauri UI</h3><p>2 agents · running</p></article>
+        <article class="mw-card"><div class="kicker">db</div><h3>Postgres migration</h3><p>1 agent · running</p></article>
+        <article class="mw-card"><div class="kicker">ci-α</div><h3>Unit tests</h3><p>2 agents · running</p></article>
+        <article class="mw-card"><div class="kicker">ci-β</div><h3>Integration tests</h3><p>1 agent · running</p></article>
+        <article class="mw-card"><div class="kicker">review</div><h3>Merge review</h3><p>2 agents · running</p></article>
+      </div>
+    </div>`;
+}
+
+function templateTimeline() {
+  return `
+    <div class="mw-page-head"><div><div class="kicker">Observability</div><h1>Timeline</h1></div></div>
+    <div class="mw-page-body">
+      <div class="mw-timeline">
+        <div class="item"><span>14:08</span><div>Session started from Home prompt.</div></div>
+        <div class="item"><span>14:09</span><div>Planner emitted task graph and topology.</div></div>
+        <div class="item"><span>14:10</span><div>Agents spawned in backend/frontend/db sandboxes.</div></div>
+        <div class="item"><span>14:14</span><div>auth-1 requested policy clarification.</div></div>
+        <div class="item"><span>14:16</span><div>tests-unit passed initial checkpoint.</div></div>
+      </div>
+    </div>`;
+}
+
+function templateSettings() {
+  return `
+    <div class="mw-page-head"><div><div class="kicker">Preferences</div><h1>Settings</h1></div></div>
+    <div class="mw-page-body">
+      <div class="mw-grid-2">
+        <div class="mw-card"><div class="kicker">Runtime</div><label><input id="daemon-toggle" type="checkbox" ${appState.daemonConnected ? 'checked' : ''}/> Daemon connected</label></div>
+        <div class="mw-card"><div class="kicker">Theme</div><label>Accent hue <input id="hue" type="range" min="180" max="260" value="260"/></label></div>
+      </div>
+    </div>`;
+}
+
+const templates = {
+  welcome: templateWelcome,
+  home: templateHome,
+  session: templateSession,
+  agent: templateAgentDetail,
+  sandboxes: templateSandboxes,
+  timeline: templateTimeline,
+  settings: templateSettings
+};
+
+function renderScreen() {
+  document.getElementById('screen-label').textContent = appState.screen[0].toUpperCase() + appState.screen.slice(1);
+  document.getElementById('session-label').textContent = appState.sessionName;
+  main.innerHTML = templates[appState.screen]();
+  wireScreenEvents();
+}
+
+function wireScreenEvents() {
+  document.getElementById('continue-btn')?.addEventListener('click', () => {
+    appState.screen = 'home';
+    setActiveNav('home');
+    renderScreen();
+  });
+
+  document.getElementById('run-task')?.addEventListener('click', () => {
+    const txt = document.getElementById('task-input').value.trim();
+    if (txt) appState.sessionName = txt.slice(0, 28);
+    appState.screen = 'session';
+    setActiveNav('session');
+    renderScreen();
+  });
+
+  document.getElementById('daemon-toggle')?.addEventListener('change', (e) => {
+    appState.daemonConnected = e.target.checked;
+    document.getElementById('daemon-status').textContent = appState.daemonConnected ? 'DAEMON' : 'OFFLINE';
+    renderStatusBar();
+  });
+
+  document.getElementById('hue')?.addEventListener('input', (e) => {
+    const hue = e.target.value;
+    document.documentElement.style.setProperty('--blue', `hsl(${hue}, 100%, 60%)`);
+    document.documentElement.style.setProperty('--blue-glow', `hsla(${hue}, 100%, 60%, 0.55)`);
+  });
+}
+
+function setActiveNav(id) {
+  document.querySelectorAll('.mw-nav-item').forEach((node) => node.classList.toggle('active', node.dataset.screen === id));
+}
+
+document.querySelectorAll('.mw-nav-item').forEach((item) => {
+  item.addEventListener('click', () => {
+    const screen = item.dataset.screen;
+    appState.screen = screen;
+    setActiveNav(screen);
+    renderScreen();
+  });
+});
+
+async function hydrateFromTauri() {
+  if (!window.__TAURI__?.core?.invoke) return;
+  try {
+    const payload = await window.__TAURI__.core.invoke('app_health');
+    document.getElementById('build-version').textContent = payload.version;
+    appState.daemonConnected = payload.daemon_connected;
+    appState.tokensPerHour = payload.tokens_per_hour;
+    renderStatusBar();
+  } catch (e) {
+    console.warn('Failed to invoke tauri command', e);
+  }
+}
+
+renderAgents();
+renderScreen();
+renderStatusBar();
+hydrateFromTauri();

--- a/mowis-desktop/src/styles.css
+++ b/mowis-desktop/src/styles.css
@@ -1,0 +1,946 @@
+/* MowisAI — minimal editorial dark UI */
+:root {
+  --bg: #000000;
+  --bg-1: #08090a;
+  --bg-2: #0e0f11;
+  --bg-3: #15171a;
+  --line: rgba(255,255,255,0.07);
+  --line-2: rgba(255,255,255,0.12);
+  --tx: #f4f4f5;
+  --tx-2: rgba(244,244,245,0.72);
+  --tx-3: rgba(244,244,245,0.48);
+  --tx-4: rgba(244,244,245,0.30);
+  --blue: #2f86ff;
+  --blue-soft: rgba(47,134,255,0.18);
+  --blue-glow: rgba(47,134,255,0.55);
+  --serif: 'Tinos', 'Georgia', 'Times New Roman', serif;
+  --sans: -apple-system, BlinkMacSystemFont, 'Inter', 'SF Pro Text', system-ui, sans-serif;
+  --mono: 'JetBrains Mono', 'SF Mono', ui-monospace, Menlo, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: #1a1a1a;
+  color: var(--tx);
+  font-family: var(--serif);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+::-webkit-scrollbar { width: 0; height: 0; }
+
+/* App window — black canvas with a faint hairline border */
+.mw-app {
+  width: 1280px;
+  height: 800px;
+  background: var(--bg);
+  border-radius: 12px;
+  overflow: hidden;
+  position: relative;
+  box-shadow: 0 30px 80px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.06);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--serif);
+}
+
+/* Title bar — minimal: traffic lights + centered breadcrumb */
+.mw-titlebar {
+  height: 36px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(0,0,0,0.4);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  position: relative;
+  z-index: 5;
+}
+.mw-traffic { display: flex; gap: 8px; align-items: center; }
+.mw-traffic span {
+  width: 12px; height: 12px; border-radius: 50%;
+  background: rgba(255,255,255,0.10);
+  border: 0.5px solid rgba(255,255,255,0.06);
+}
+.mw-titlebar-center {
+  position: absolute; left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--serif);
+  font-size: 13px;
+  color: var(--tx-3);
+  letter-spacing: 0.02em;
+  display: flex; align-items: center; gap: 10px;
+}
+.mw-titlebar-center .sep { color: var(--tx-4); }
+.mw-titlebar-right {
+  margin-left: auto;
+  display: flex; align-items: center; gap: 14px;
+  font-family: var(--sans);
+  font-size: 11px;
+  color: var(--tx-3);
+  letter-spacing: 0.04em;
+}
+.mw-status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--blue);
+  box-shadow: 0 0 10px var(--blue-glow);
+  margin-right: 6px;
+  display: inline-block;
+}
+
+/* App body — sidebar + main + agents panel */
+.mw-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+/* Left sidebar */
+.mw-sidebar {
+  width: 196px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  padding: 22px 16px 16px 18px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.012), rgba(255,255,255,0));
+}
+.mw-brand {
+  font-family: var(--serif);
+  font-size: 18px;
+  font-style: italic;
+  letter-spacing: 0.01em;
+  color: var(--tx);
+  margin-bottom: 36px;
+  padding-left: 4px;
+}
+.mw-brand .dot {
+  display: inline-block;
+  width: 5px; height: 5px;
+  background: var(--blue);
+  border-radius: 50%;
+  margin-left: 4px;
+  vertical-align: middle;
+  box-shadow: 0 0 8px var(--blue-glow);
+}
+.mw-section-label {
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--tx-4);
+  padding-left: 8px;
+  margin: 22px 0 8px;
+}
+.mw-nav-item {
+  font-family: var(--serif);
+  font-size: 14px;
+  color: var(--tx-2);
+  padding: 7px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  letter-spacing: 0.01em;
+}
+.mw-nav-item:hover { background: rgba(255,255,255,0.03); color: var(--tx); }
+.mw-nav-item.active {
+  color: var(--tx);
+  background: rgba(255,255,255,0.04);
+}
+.mw-nav-item .badge {
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-3);
+  letter-spacing: 0.04em;
+}
+.mw-sidebar-spacer { flex: 1; }
+.mw-sidebar-foot {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-4);
+  letter-spacing: 0.04em;
+  line-height: 1.6;
+}
+
+/* Main workspace */
+.mw-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Right agents panel */
+.mw-agents {
+  width: 280px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(255,255,255,0.012), rgba(255,255,255,0));
+}
+.mw-agents-head {
+  padding: 18px 18px 14px;
+  border-bottom: 1px solid var(--line);
+}
+.mw-agents-head .title {
+  font-family: var(--serif);
+  font-size: 14px;
+  color: var(--tx);
+  letter-spacing: 0.01em;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.mw-agents-head .meta {
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-4);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-top: 6px;
+}
+.mw-agents-head .count-row {
+  margin-top: 14px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.mw-agents-head .count {
+  font-family: var(--serif);
+  font-size: 36px;
+  font-weight: 400;
+  color: var(--tx);
+  letter-spacing: -0.01em;
+  line-height: 1;
+}
+.mw-agents-head .count-label {
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-3);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+/* Agent grid: rounded gray squares */
+.mw-agent-grid {
+  padding: 16px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  flex: 1;
+  align-content: start;
+  overflow-y: auto;
+}
+.mw-agent-tile {
+  aspect-ratio: 1;
+  border-radius: 9px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.04);
+  position: relative;
+  cursor: pointer;
+  transition: background .15s ease, border-color .15s ease, transform .15s ease;
+  display: flex;
+  align-items: flex-end;
+  padding: 7px;
+}
+.mw-agent-tile:hover {
+  background: rgba(255,255,255,0.08);
+  border-color: rgba(255,255,255,0.10);
+}
+.mw-agent-tile .id {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--tx-3);
+  letter-spacing: 0.04em;
+}
+.mw-agent-tile.running {
+  background: rgba(47,134,255,0.10);
+  border-color: rgba(47,134,255,0.28);
+}
+.mw-agent-tile.running::before {
+  content: "";
+  position: absolute;
+  top: 7px; right: 7px;
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: var(--blue);
+  box-shadow: 0 0 8px var(--blue-glow);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+.mw-agent-tile.idle::before {
+  content: "";
+  position: absolute;
+  top: 7px; right: 7px;
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.20);
+}
+.mw-agent-tile.done::before {
+  content: "";
+  position: absolute;
+  top: 7px; right: 7px;
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.45);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.85); }
+}
+
+/* Hover popover for agent */
+.mw-agent-pop {
+  position: absolute;
+  top: 50%;
+  right: calc(100% + 12px);
+  transform: translateY(-50%);
+  width: 240px;
+  background: rgba(20,21,23,0.92);
+  -webkit-backdrop-filter: blur(24px);
+  backdrop-filter: blur(24px);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 10px;
+  padding: 14px;
+  font-family: var(--serif);
+  font-size: 12px;
+  color: var(--tx-2);
+  z-index: 20;
+  pointer-events: none;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.6);
+}
+.mw-agent-pop .name {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--tx-3);
+  letter-spacing: 0.06em;
+  margin-bottom: 10px;
+}
+.mw-agent-pop .task {
+  font-family: var(--serif);
+  font-size: 13px;
+  color: var(--tx);
+  line-height: 1.4;
+  margin-bottom: 10px;
+}
+.mw-agent-pop .row {
+  display: flex; justify-content: space-between;
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-3);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+.mw-agent-pop .row b {
+  color: var(--tx);
+  font-weight: 500;
+}
+
+/* Footer status bar */
+.mw-statusbar {
+  height: 26px;
+  flex-shrink: 0;
+  border-top: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  gap: 22px;
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-4);
+  letter-spacing: 0.08em;
+  background: rgba(0,0,0,0.5);
+}
+.mw-statusbar .sep { opacity: 0.4; }
+.mw-statusbar b {
+  color: var(--tx-2);
+  font-weight: 400;
+}
+
+/* Buttons */
+.mw-btn {
+  font-family: var(--serif);
+  font-size: 13px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  color: var(--tx);
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all .15s;
+  letter-spacing: 0.01em;
+}
+.mw-btn:hover { background: rgba(255,255,255,0.07); border-color: rgba(255,255,255,0.14); }
+.mw-btn.primary {
+  background: var(--blue);
+  border-color: var(--blue);
+  color: #fff;
+  box-shadow: 0 4px 24px rgba(47,134,255,0.32);
+}
+.mw-btn.primary:hover {
+  background: #4495ff;
+  box-shadow: 0 6px 32px rgba(47,134,255,0.48);
+}
+.mw-btn.ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--tx-2);
+}
+.mw-btn.ghost:hover { background: rgba(255,255,255,0.04); color: var(--tx); }
+
+/* Chat / stream */
+.mw-chat {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 56px;
+}
+.mw-chat .turn { margin-bottom: 28px; }
+.mw-chat .role {
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--tx-4);
+  margin-bottom: 8px;
+}
+.mw-chat .body {
+  font-family: var(--serif);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--tx);
+  letter-spacing: 0.005em;
+}
+.mw-chat .body.muted { color: var(--tx-2); }
+.mw-chat .system {
+  font-family: var(--sans);
+  font-size: 11px;
+  color: var(--tx-3);
+  letter-spacing: 0.04em;
+  padding: 6px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  margin: 18px 0;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+.mw-chat .system .tag {
+  color: var(--blue);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+
+/* Composer at bottom of chat */
+.mw-composer {
+  border-top: 1px solid var(--line);
+  padding: 14px 56px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: rgba(0,0,0,0.5);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+}
+.mw-composer .input {
+  font-family: var(--serif);
+  font-size: 14px;
+  color: var(--tx);
+  background: transparent;
+  border: none;
+  outline: none;
+  width: 100%;
+  resize: none;
+  height: 24px;
+  line-height: 1.5;
+}
+.mw-composer .input::placeholder { color: var(--tx-4); }
+.mw-composer .row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.mw-composer .chip {
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-3);
+  padding: 4px 10px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.mw-composer .send {
+  margin-left: auto;
+}
+
+/* Welcome screen */
+.mw-welcome {
+  width: 100%; height: 100%;
+  background: #000;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mw-welcome .word {
+  font-family: var(--serif);
+  font-size: 72px;
+  font-weight: 400;
+  color: #fff;
+  letter-spacing: -0.01em;
+  filter: blur(var(--welcome-blur, 14px));
+  transition: filter 4s cubic-bezier(.2,.7,.2,1);
+}
+.mw-welcome .continue {
+  position: absolute;
+  bottom: 56px;
+  right: 56px;
+}
+.mw-welcome .continue button {
+  font-family: var(--serif);
+  font-size: 14px;
+  color: #fff;
+  background: var(--blue);
+  border: none;
+  padding: 10px 22px;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 6px 28px rgba(47,134,255,0.48);
+}
+
+/* Generic page layouts */
+.mw-page {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.mw-page-head {
+  padding: 32px 48px 22px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+.mw-page-head h1 {
+  font-family: var(--serif);
+  font-size: 30px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  margin: 0 0 6px;
+  color: var(--tx);
+}
+.mw-page-head .sub {
+  font-family: var(--sans);
+  font-size: 11px;
+  color: var(--tx-4);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.mw-page-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 28px 48px 40px;
+}
+
+/* Tables — editorial */
+.mw-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--serif);
+}
+.mw-table th {
+  text-align: left;
+  font-family: var(--sans);
+  font-size: 10px;
+  font-weight: 400;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--tx-4);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+}
+.mw-table td {
+  padding: 16px 14px;
+  border-bottom: 1px solid var(--line);
+  font-size: 14px;
+  color: var(--tx-2);
+  vertical-align: middle;
+}
+.mw-table td.tx { color: var(--tx); }
+.mw-table tr:hover td { background: rgba(255,255,255,0.015); }
+.mw-table .mono { font-family: var(--mono); font-size: 12px; color: var(--tx-3); letter-spacing: 0.02em; }
+.mw-table .pill {
+  font-family: var(--sans);
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--line-2);
+  color: var(--tx-2);
+  display: inline-block;
+}
+.mw-table .pill.running { color: var(--blue); border-color: rgba(47,134,255,0.4); background: rgba(47,134,255,0.06); }
+.mw-table .pill.done { color: var(--tx-2); }
+.mw-table .pill.queued { color: var(--tx-3); }
+
+/* Big number stat block */
+.mw-stat {
+  padding: 22px 0;
+  border-bottom: 1px solid var(--line);
+}
+.mw-stat:last-child { border-bottom: none; }
+.mw-stat .value {
+  font-family: var(--serif);
+  font-size: 56px;
+  letter-spacing: -0.02em;
+  color: var(--tx);
+  line-height: 1;
+  font-weight: 400;
+}
+.mw-stat .value sub {
+  font-size: 18px;
+  color: var(--tx-3);
+  margin-left: 6px;
+  vertical-align: baseline;
+}
+.mw-stat .label {
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-4);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-top: 10px;
+}
+
+/* Diff panel */
+.mw-diff {
+  border-top: 1px solid var(--line);
+  background: var(--bg-1);
+  flex-shrink: 0;
+  max-height: 220px;
+  display: flex;
+  flex-direction: column;
+}
+.mw-diff-head {
+  display: flex;
+  align-items: center;
+  padding: 10px 56px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-3);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.mw-diff-head .file { margin-right: 18px; color: var(--tx-2); }
+.mw-diff-head .file.active { color: var(--tx); }
+.mw-diff-head .actions { margin-left: auto; display: flex; gap: 10px; }
+.mw-diff-body {
+  flex: 1;
+  overflow: auto;
+  padding: 14px 56px;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--tx-2);
+}
+.mw-diff-body .add { color: #6cd49a; background: rgba(108,212,154,0.05); }
+.mw-diff-body .del { color: #ea7474; background: rgba(234,116,116,0.05); }
+.mw-diff-body .ctx { color: var(--tx-4); }
+.mw-diff-body .marker {
+  display: inline-block;
+  width: 14px;
+  color: var(--tx-4);
+  user-select: none;
+}
+
+/* Sandbox / card grid */
+.mw-cards {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+.mw-card {
+  background: var(--bg);
+  padding: 26px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 180px;
+}
+.mw-card .name {
+  font-family: var(--serif);
+  font-size: 18px;
+  color: var(--tx);
+}
+.mw-card .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--tx-3);
+  letter-spacing: 0.04em;
+}
+.mw-card .row {
+  display: flex; align-items: baseline; justify-content: space-between;
+  font-family: var(--sans);
+  font-size: 11px;
+  color: var(--tx-3);
+  letter-spacing: 0.06em;
+}
+.mw-card .row b {
+  font-family: var(--serif);
+  font-size: 15px;
+  color: var(--tx);
+  font-weight: 400;
+  letter-spacing: 0;
+}
+.mw-card .bar {
+  height: 2px;
+  background: rgba(255,255,255,0.08);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.mw-card .bar > span {
+  display: block;
+  height: 100%;
+  background: var(--blue);
+}
+
+/* Form rows (Settings) */
+.mw-form-row {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 32px;
+  padding: 22px 0;
+  border-bottom: 1px solid var(--line);
+}
+.mw-form-row .label {
+  font-family: var(--serif);
+  font-size: 15px;
+  color: var(--tx);
+}
+.mw-form-row .label .hint {
+  display: block;
+  font-family: var(--sans);
+  font-size: 11px;
+  color: var(--tx-4);
+  margin-top: 4px;
+  letter-spacing: 0.02em;
+  line-height: 1.5;
+}
+.mw-form-row .control {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.mw-input {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 9px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--tx);
+  outline: none;
+  width: 100%;
+  max-width: 420px;
+  letter-spacing: 0.02em;
+}
+.mw-input:focus { border-color: rgba(47,134,255,0.5); }
+
+/* Timeline */
+.mw-timeline {
+  padding: 0;
+}
+.mw-timeline .row {
+  display: grid;
+  grid-template-columns: 110px 1fr 110px;
+  gap: 24px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--line);
+  align-items: baseline;
+}
+.mw-timeline .time {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--tx-4);
+  letter-spacing: 0.04em;
+}
+.mw-timeline .text {
+  font-family: var(--serif);
+  font-size: 14px;
+  color: var(--tx-2);
+}
+.mw-timeline .text .who {
+  color: var(--tx);
+  font-style: italic;
+}
+.mw-timeline .meta {
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-4);
+  letter-spacing: 0.10em;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+/* Detail page two-column */
+.mw-detail {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 1px;
+  flex: 1;
+  background: var(--line);
+}
+.mw-detail > section {
+  background: var(--bg);
+  padding: 32px 36px;
+  overflow: auto;
+}
+.mw-kv {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 14px 22px;
+  font-size: 13px;
+  margin: 18px 0 0;
+}
+.mw-kv dt {
+  font-family: var(--sans);
+  font-size: 10px;
+  color: var(--tx-4);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  align-self: center;
+}
+.mw-kv dd {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 14px;
+  color: var(--tx);
+}
+.mw-kv dd.mono { font-family: var(--mono); font-size: 12px; color: var(--tx-2); }
+
+/* Spawn / new task layout */
+.mw-spawn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0 80px;
+  text-align: center;
+  gap: 28px;
+}
+.mw-spawn h1 {
+  font-family: var(--serif);
+  font-size: 38px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: var(--tx);
+  margin: 0;
+}
+.mw-spawn .lede {
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--tx-3);
+  max-width: 560px;
+  line-height: 1.55;
+  font-style: italic;
+}
+.mw-spawn-input {
+  width: 100%;
+  max-width: 640px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.10);
+  border-radius: 14px;
+  padding: 22px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.mw-spawn-input textarea {
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: none;
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--tx);
+  width: 100%;
+  height: 64px;
+  line-height: 1.4;
+}
+.mw-spawn-input textarea::placeholder { color: var(--tx-4); }
+.mw-spawn-input .controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.mw-spawn-suggestions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 700px;
+}
+.mw-suggestion {
+  font-family: var(--serif);
+  font-size: 13px;
+  color: var(--tx-2);
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  padding: 7px 14px;
+  cursor: pointer;
+}
+.mw-suggestion:hover { border-color: rgba(255,255,255,0.22); color: var(--tx); }
+
+/* Range/swarm visualisation row */
+.mw-swarm {
+  display: grid;
+  grid-template-columns: repeat(48, 1fr);
+  gap: 4px;
+  margin: 18px 0 6px;
+}
+.mw-swarm span {
+  aspect-ratio: 1;
+  border-radius: 2px;
+  background: rgba(255,255,255,0.06);
+}
+.mw-swarm span.r { background: var(--blue); box-shadow: 0 0 6px var(--blue-glow); }
+.mw-swarm span.d { background: rgba(255,255,255,0.18); }
+
+.screen { display: none; padding: 32px; }
+.screen.active { display: block; }
+.screen h1 { font-size: 36px; font-weight: 400; margin: 0 0 12px; }
+.screen p { color: var(--tx-2); margin-top: 0; }
+.mw-cards { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 12px; margin-top: 20px; }
+.mw-card { border: 1px solid var(--line); background: rgba(255,255,255,0.02); border-radius: 10px; padding: 20px; }
+
+.mw-page-head { display:flex; justify-content:space-between; align-items:center; padding:26px 28px 16px; border-bottom:1px solid var(--line); }
+.mw-page-head .kicker { font-family:var(--sans); text-transform:uppercase; letter-spacing:.14em; font-size:10px; color:var(--tx-4); margin-bottom:6px; }
+.mw-page-head h1 { margin:0; font-size:34px; font-weight:400; font-style:italic; }
+.mw-page-body { padding:24px 28px; overflow-y:auto; }
+.mw-grid-2 { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; }
+.mw-grid-3 { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:14px; }
+.mw-card h3 { margin:8px 0 6px; font-size:18px; font-weight:400; font-style:italic; }
+.mw-card p { margin:0; color:var(--tx-2); }
+.mw-code { margin-top:14px; border:1px solid var(--line); border-radius:10px; background:#050607; color:#c7d5ff; font-family:var(--mono); padding:14px; white-space:pre-wrap; }
+.mw-timeline { border-top:1px solid var(--line); }
+.mw-timeline .item { display:grid; grid-template-columns:80px 1fr; gap:14px; border-bottom:1px solid var(--line); padding:12px 0; }
+.mw-timeline .item span { font-family:var(--mono); color:var(--tx-3); font-size:11px; }

--- a/mowis-desktop/vite.config.js
+++ b/mowis-desktop/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 1420,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
### Motivation

- Provide a minimal Tauri-based desktop UI for MowisAI to inspect sessions, agents, sandboxes and status during development.
- Ship a lightweight local frontend scaffold and a small Rust command to expose runtime health information to the UI via `app_health`.

### Description

- Add a static frontend: `index.html`, `src/main.js` with mock agent data and UI templates, and `src/styles.css` with the full dark-theme UI stylesheet and component styles.
- Add build/dev tooling: `package.json` with `vite` scripts and `vite.config.js` configured to serve on port `1420`.
- Add Tauri Rust backend and config: `src-tauri/Cargo.toml`, `src-tauri/build.rs`, `src-tauri/src/main.rs` exposing the `app_health` command, and `src-tauri/tauri.conf.json` for application metadata and window settings.
- Wire frontend to Tauri: `src/main.js` calls the `app_health` invoke if available to hydrate build/version, daemon connection and tokens-per-hour.

### Testing

- No automated tests were included or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d3858d90832aa7416526f68f625d)