### PR TITLE
Add intent classification and chat mode to TUI

### DIFF
--- a/agentd/src/tui/app.rs
+++ b/agentd/src/tui/app.rs
@@ -1,4 +1,5 @@
 use crate::config::MowisConfig;
+use crate::intent::{classify_intent, UserIntent};
 use crate::orchestration::ComplexityMode;
 use crate::tui::event::{OrchActivityEvent, TuiEvent};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -405,19 +406,84 @@ impl App {
     fn handle_user_input(&mut self, text: String) {
         self.messages.push(ChatMessage { role: MessageRole::User, content: text.clone() });
 
-        let mode_label = match &self.mode_override {
-            Some(ComplexityMode::Simple) => " [simple mode]",
-            Some(ComplexityMode::Standard) => " [standard mode]",
-            Some(ComplexityMode::Full) => " [full mode]",
-            None => "",
+        match classify_intent(&text) {
+            UserIntent::Build => {
+                let mode_label = match &self.mode_override {
+                    Some(ComplexityMode::Simple) => " [simple mode]",
+                    Some(ComplexityMode::Standard) => " [standard mode]",
+                    Some(ComplexityMode::Full) => " [full mode]",
+                    None => "",
+                };
+                self.messages.push(ChatMessage {
+                    role: MessageRole::System,
+                    content: format!("Build request detected{} -- launching orchestration...", mode_label),
+                });
+                self.start_orchestration(text);
+            }
+            UserIntent::Chat => {
+                self.start_chat(text);
+            }
+        }
+    }
+
+    fn start_chat(&mut self, message: String) {
+        self.is_loading = true;
+
+        let tx = match &self.event_tx {
+            Some(t) => t.clone(),
+            None => {
+                self.messages.push(ChatMessage {
+                    role: MessageRole::System,
+                    content: "Cannot send chat: no event channel.".to_string(),
+                });
+                self.is_loading = false;
+                return;
+            }
         };
 
-        self.messages.push(ChatMessage {
-            role: MessageRole::System,
-            content: format!("Build request detected{} -- launching orchestration...", mode_label),
-        });
+        let config = self.config.clone();
 
-        self.start_orchestration(text);
+        std::thread::spawn(move || {
+            let rt = match tokio::runtime::Runtime::new() {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.send(TuiEvent::GeminiError(e.to_string()));
+                    let _ = tx.send(TuiEvent::GeminiDone);
+                    return;
+                }
+            };
+
+            rt.block_on(async move {
+                let llm_config = match crate::orchestration::provider_client::LlmConfig::from_config(&config) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx.send(TuiEvent::GeminiError(e.to_string()));
+                        let _ = tx.send(TuiEvent::GeminiDone);
+                        return;
+                    }
+                };
+
+                let system_prompt = "You are MowisAI, an AI coding assistant. Answer the user's question helpfully and concisely.";
+
+                match crate::orchestration::provider_client::generate_text(
+                    &llm_config,
+                    system_prompt,
+                    &message,
+                    false,
+                    0.7,
+                )
+                .await
+                {
+                    Ok(response) => {
+                        let _ = tx.send(TuiEvent::GeminiChunk(response));
+                    }
+                    Err(e) => {
+                        let _ = tx.send(TuiEvent::GeminiError(e.to_string()));
+                    }
+                }
+                let _ = tx.send(TuiEvent::GeminiDone);
+            });
+        });
     }
 
     fn start_orchestration(&mut self, prompt: String) {


### PR DESCRIPTION
## Summary
This PR adds intent classification to the TUI's input handling, enabling the app to distinguish between build requests and general chat messages. When a user sends a chat message (non-build intent), the app now routes it to a new chat handler instead of always treating input as a build request.

## Key Changes
- **Intent Classification**: Integrated `classify_intent()` to determine whether user input is a build request or chat message
- **Chat Handler**: Added new `start_chat()` method that:
  - Spawns an async task to call the LLM provider with a generic system prompt
  - Streams responses back to the TUI via the event channel
  - Handles errors gracefully with appropriate error messages
- **Input Routing**: Modified `handle_user_input()` to route messages based on classified intent:
  - `UserIntent::Build` → launches orchestration (existing behavior)
  - `UserIntent::Chat` → calls new chat handler
- **Mode Label**: Moved mode override label generation into the build intent branch since it's only relevant for orchestration

## Implementation Details
- The chat handler uses the same LLM configuration and provider client as orchestration
- Chat requests use a fixed system prompt ("You are MowisAI, an AI coding assistant...") with temperature 0.7
- The implementation follows the same async/threading pattern as the existing orchestration flow
- Error handling ensures the loading state is properly managed and users are notified of failures

https://claude.ai/code/session_01FxMsujL3WxoXbtAZSab5bY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat interactions now feature real-time response streaming with improved reliability
  * Enhanced error handling ensures clearer feedback when requests fail
  * Smarter message classification for better routing of different request types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->