### PR TITLE
fix: agent mode no longer falls through to simulation

### DIFF
--- a/mowis-desktop/index.html
+++ b/mowis-desktop/index.html
@@ -600,6 +600,35 @@
 </div><!-- /#app -->
 
 
+<!-- Agent startup modal -->
+<div id="agent-startup-modal" class="engine-modal hidden" aria-hidden="true">
+  <div class="engine-modal-backdrop"></div>
+  <div class="engine-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="agent-startup-title">
+    <div class="engine-modal-head">
+      <div class="engine-modal-icon">&#129302;</div>
+      <div>
+        <div class="engine-modal-title" id="agent-startup-title">Starting mowis-agent</div>
+        <div class="engine-modal-subtitle" id="agent-startup-subtitle">Connecting to the agent process...</div>
+      </div>
+    </div>
+    <div class="engine-modal-body">
+      <div class="agent-startup-spinner" id="agent-startup-spinner">
+        <div class="spinner-dot"></div>
+        <span id="agent-startup-spinner-text">Starting up...</span>
+      </div>
+      <div class="agent-startup-log" id="agent-startup-log"></div>
+      <div class="engine-error hidden" id="agent-startup-error">
+        <div class="engine-error-title">Agent failed to start</div>
+        <div class="engine-error-message" id="agent-startup-error-msg"></div>
+      </div>
+      <div class="agent-startup-actions hidden" id="agent-startup-actions">
+        <button class="wizard-btn wizard-btn-secondary" id="btn-agent-startup-cancel">Cancel</button>
+        <button class="wizard-btn wizard-btn-primary" id="btn-agent-startup-retry">Retry</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Repository picker -->
 <div id="repo-modal" class="repo-modal hidden" aria-hidden="true">
   <div class="repo-backdrop" id="repo-backdrop"></div>

--- a/mowis-desktop/src-tauri/src/commands.rs
+++ b/mowis-desktop/src-tauri/src/commands.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
-use tauri::{Manager, State};
+use tauri::{Emitter, Manager, State};
 use tokio::process::Command;
 use uuid::Uuid;
 
@@ -792,4 +792,80 @@ pub async fn agent_delete_session(
 ) -> Result<(), String> {
     let client = get_agent_client(&state)?;
     client.delete_session(&session_id).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn agent_list_messages(
+    state: State<'_, Arc<AppState>>,
+    session_id: String,
+) -> Result<Vec<agent_client::AgentMessage>, String> {
+    let client = get_agent_client(&state)?;
+    client.list_messages(&session_id).await.map_err(|e| e.to_string())
+}
+
+/// Explicitly start (or connect to) the mowis-agent subprocess.
+/// Emits `agent_startup_log` events with `{ text, level }` as it progresses
+/// so the frontend can display live logs in the startup modal.
+#[tauri::command]
+pub async fn agent_start(
+    app: tauri::AppHandle,
+    state: State<'_, Arc<AppState>>,
+) -> Result<serde_json::Value, String> {
+    // Release lock before any await — sync Mutex must not be held across await points.
+    let maybe_client = {
+        let lock = state.agent_manager.lock().map_err(|e| e.to_string())?;
+        lock.as_ref().map(|m| (m.client().clone(), m.port()))
+    };
+
+    if let Some((client, port)) = maybe_client {
+        if let Ok(health) = client.health().await {
+            if health.healthy {
+                let _ = app.emit("agent_startup_log", serde_json::json!({
+                    "text": format!("Agent already running on port {} (v{})", port, health.version),
+                    "level": "success"
+                }));
+                return Ok(serde_json::json!({ "port": port, "already_running": true }));
+            }
+        }
+    }
+
+    let resource_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        .unwrap_or_default();
+
+    let _ = app.emit("agent_startup_log", serde_json::json!({
+        "text": format!("Searching for mowis-agent in: {}", resource_dir.display()),
+        "level": "info"
+    }));
+    let _ = app.emit("agent_startup_log", serde_json::json!({
+        "text": format!(
+            "Scanning ports {}–{} for a running instance...",
+            crate::agent_manager::DEFAULT_AGENT_PORT,
+            crate::agent_manager::DEFAULT_AGENT_PORT + 9
+        ),
+        "level": "info"
+    }));
+
+    let mut mgr = crate::agent_manager::AgentManager::new(crate::agent_manager::DEFAULT_AGENT_PORT);
+
+    match mgr.start(&resource_dir).await {
+        Ok(()) => {
+            let port = mgr.port();
+            let _ = app.emit("agent_startup_log", serde_json::json!({
+                "text": format!("mowis-agent ready on port {}", port),
+                "level": "success"
+            }));
+            *state.agent_manager.lock().map_err(|e| e.to_string())? = Some(mgr);
+            Ok(serde_json::json!({ "port": port }))
+        }
+        Err(e) => {
+            let msg = format!("{:#}", e);
+            let _ = app.emit("agent_startup_log", serde_json::json!({
+                "text": msg.clone(),
+                "level": "error"
+            }));
+            Err(msg)
+        }
+    }
 }

--- a/mowis-desktop/src-tauri/src/main.rs
+++ b/mowis-desktop/src-tauri/src/main.rs
@@ -70,6 +70,8 @@ fn main() {
             agent_list_sessions,
             agent_health,
             agent_delete_session,
+            agent_list_messages,
+            agent_start,
         ])
         .run(tauri::generate_context!())
         .expect("error running mowis-desktop");

--- a/mowis-desktop/src/main.js
+++ b/mowis-desktop/src/main.js
@@ -526,12 +526,101 @@ async function setupListeners() {
   });
 }
 
-// ── Session start (via mowis-agent) ─────────────────────────────────────────
+// ── Agent startup modal ───────────────────────────────────────────────────────
+
+async function startAgentWithModal() {
+  return new Promise((resolve) => {
+    const modal    = $('agent-startup-modal');
+    const logEl    = $('agent-startup-log');
+    const spinner  = $('agent-startup-spinner');
+    const spinnerText = $('agent-startup-spinner-text');
+    const subtitle = $('agent-startup-subtitle');
+    const errorEl  = $('agent-startup-error');
+    const errorMsg = $('agent-startup-error-msg');
+    const actionsEl = $('agent-startup-actions');
+    const cancelBtn = $('btn-agent-startup-cancel');
+    const retryBtn  = $('btn-agent-startup-retry');
+
+    if (!modal) { resolve(false); return; }
+
+    let unlistenLog = null;
+    const cleanups = [];
+
+    function addLogLine(text, level) {
+      if (!logEl) return;
+      const line = document.createElement('div');
+      line.className = `agent-log-line ${level || 'info'}`;
+      const pre = document.createElement('span');
+      pre.className = 'agent-log-prefix';
+      pre.textContent = level === 'success' ? '✓' : level === 'error' ? '✗' : '›';
+      const txt = document.createElement('span');
+      txt.textContent = text;
+      line.appendChild(pre);
+      line.appendChild(txt);
+      logEl.appendChild(line);
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function resetUI() {
+      if (logEl) logEl.innerHTML = '';
+      if (errorEl) errorEl.classList.add('hidden');
+      if (actionsEl) actionsEl.classList.add('hidden');
+      if (spinner) { spinner.classList.remove('done', 'error'); }
+      if (subtitle) subtitle.textContent = 'Connecting to the agent process...';
+      if (spinnerText) spinnerText.textContent = 'Starting up...';
+    }
+
+    function closeModal() {
+      modal.classList.add('hidden');
+      modal.setAttribute('aria-hidden', 'true');
+      cleanups.forEach(fn => fn());
+    }
+
+    // Subscribe to live log events from the backend
+    listen('agent_startup_log', (e) => {
+      addLogLine(e.payload?.text, e.payload?.level);
+    }).then(u => { unlistenLog = u; cleanups.push(u); });
+
+    function tryStart() {
+      invoke('agent_start')
+        .then(() => {
+          if (spinner) spinner.classList.add('done');
+          if (spinnerText) spinnerText.textContent = 'Agent connected';
+          if (subtitle) subtitle.textContent = 'mowis-agent is ready';
+          State.agentHealthy = true;
+          setTimeout(() => { closeModal(); resolve(true); }, 500);
+        })
+        .catch((err) => {
+          if (spinner) spinner.classList.add('error');
+          if (spinnerText) spinnerText.textContent = 'Failed to start';
+          if (subtitle) subtitle.textContent = 'Agent could not be started';
+          if (errorEl) errorEl.classList.remove('hidden');
+          if (errorMsg) errorMsg.textContent = String(err);
+          if (actionsEl) actionsEl.classList.remove('hidden');
+        });
+    }
+
+    const onCancel = () => { closeModal(); resolve(false); };
+    const onRetry  = () => { resetUI(); tryStart(); };
+    cancelBtn?.addEventListener('click', onCancel);
+    retryBtn?.addEventListener('click', onRetry);
+    cleanups.push(() => cancelBtn?.removeEventListener('click', onCancel));
+    cleanups.push(() => retryBtn?.removeEventListener('click', onRetry));
+
+    resetUI();
+    modal.classList.remove('hidden');
+    modal.setAttribute('aria-hidden', 'false');
+    tryStart();
+  });
+}
+
+// ── Session start ─────────────────────────────────────────────────────────────
 
 export async function startSession(prompt, mode, repo = State.selectedRepo) {
   if (!prompt.trim() && pendingAttachments.length === 0) { toast('Enter a task description', 'error'); return; }
 
   const fullPrompt = prompt.trim();
+  const agentModeRequested = mode === 'agent';
   clearAttachments();
 
   State.tasks = {};
@@ -563,6 +652,7 @@ export async function startSession(prompt, mode, repo = State.selectedRepo) {
   updateTaskPanelVisibility();
 
   try {
+    // Re-check health if we think it's unhealthy
     if (!State.agentHealthy) {
       try {
         const health = await invoke('agent_health');
@@ -571,6 +661,20 @@ export async function startSession(prompt, mode, repo = State.selectedRepo) {
       } catch (e) {
         console.warn('[session] Agent re-check failed:', e);
         State.agentHealthy = false;
+      }
+    }
+
+    // When agent mode is explicitly requested and agent isn't running,
+    // show the startup modal — never silently fall back to simulation.
+    if (agentModeRequested && !State.agentHealthy) {
+      console.log('[session] Agent mode requested but not healthy — showing startup modal');
+      const started = await startAgentWithModal();
+      if (!started) {
+        // User cancelled or agent failed — abort cleanly, no simulation
+        removeThinkingIndicator();
+        setSessionActive(false);
+        navigate('home', { preserveHomeMode: true });
+        return;
       }
     }
 
@@ -593,8 +697,12 @@ export async function startSession(prompt, mode, repo = State.selectedRepo) {
       });
       console.log('[session] ✓ Message sent, starting polling');
       startAgentPolling(session.id);
+    } else if (agentModeRequested) {
+      // Startup modal succeeded but health is still false — shouldn't happen, but guard it
+      throw new Error('mowis-agent is not available. Check that the binary is installed alongside the app.');
     } else {
-      console.log('[session] Agent not healthy — falling back to orchestration');
+      // Non-agent mode: use orchestration (real daemon or simulation fallback)
+      console.log('[session] Using orchestration mode:', mode || 'auto');
       const id = await invoke('start_session', {
         prompt: fullPrompt,
         mode: mode || 'auto',

--- a/mowis-desktop/src/styles/modals.css
+++ b/mowis-desktop/src/styles/modals.css
@@ -189,6 +189,71 @@
   background: rgba(59,139,255,0.18);
 }
 
+/* ── Agent Startup Modal ─────────────────────────────────────────────────── */
+.agent-startup-spinner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  font-size: 13px;
+  color: var(--tx-2);
+}
+.agent-startup-spinner .spinner-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--blue);
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+.agent-startup-spinner.done .spinner-dot {
+  background: #81C784;
+  animation: none;
+}
+.agent-startup-spinner.error .spinner-dot {
+  background: #EF9A9A;
+  animation: none;
+}
+@keyframes pulse-dot {
+  0%, 100% { opacity: 0.3; transform: scale(0.8); }
+  50%       { opacity: 1;   transform: scale(1.2); }
+}
+.agent-startup-log {
+  background: rgba(0,0,0,0.35);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r);
+  padding: 12px 14px;
+  margin-bottom: 0;
+  min-height: 60px;
+  max-height: 260px;
+  overflow-y: auto;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.75;
+}
+.agent-log-line {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+.agent-log-line.info    { color: var(--tx-3); }
+.agent-log-line.success { color: #81C784; }
+.agent-log-line.error   { color: #EF9A9A; }
+.agent-log-prefix {
+  flex-shrink: 0;
+  opacity: 0.6;
+  user-select: none;
+  width: 10px;
+  text-align: center;
+}
+.agent-startup-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+}
+
 /* ── Diff Viewer Modal ──────────────────────────────────────────────────────── */
 .diff-viewer-overlay {
   position: fixed;


### PR DESCRIPTION
When the user explicitly selects "agent" mode from the chat input
dropdown, the app now correctly:
- Detects that mowis-agent isn't running
- Shows a transparent startup modal with live log output
  (binary location, port scan, health-check progress, errors)
- Calls the new agent_start Tauri command to spawn mowis-agent.exe
  and wait for it to become healthy
- Proceeds to create an agent session on success
- Shows Cancel / Retry on failure — never silently runs simulation

Previously the mode param was ignored entirely; routing was based
solely on State.agentHealthy which was only set at splash time, so
"agent" mode always fell through to the orchestration/simulation path.

Also adds missing agent_list_messages Tauri command (was called by
the frontend polling loop but never registered in the invoke_handler).

https://claude.ai/code/session_01PLk6LXDBrQzfmvQ6Bq5bD1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced agent startup modal that displays real-time initialization progress with live status updates and logged output
  * Added ability to retry or cancel agent startup if initialization encounters issues
  * Enhanced agent mode workflow with improved visibility into the startup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->