### PR TITLE
Add live event streaming pipeline from agentd to desktop UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,8 +1598,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1603,9 +1611,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2058,6 +2068,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2615,6 +2626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2739,11 +2756,13 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "dirs 5.0.1",
+ "futures-util",
  "gcp_auth",
  "hex",
  "lazy_static",
  "log",
  "rand 0.8.6",
+ "reqwest 0.12.28",
  "rsa",
  "serde",
  "serde_json",
@@ -3593,6 +3612,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.3",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,8 +3960,49 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3925,7 +4040,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4094,6 +4209,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5411,6 +5527,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6060,6 +6191,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -6088,6 +6232,16 @@ name = "web-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6163,6 +6317,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "webview2-com"

--- a/mowis-desktop/package-lock.json
+++ b/mowis-desktop/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "mowis-desktop",
-  "version": "0.1.0",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mowis-desktop",
-      "version": "0.1.0",
+      "version": "0.2.4",
       "dependencies": {
         "@tauri-apps/api": "~2.0.0",
-        "@tauri-apps/plugin-dialog": "~2.0.0"
+        "@tauri-apps/plugin-dialog": "~2.0.0",
+        "@tauri-apps/plugin-process": "~2.0.0",
+        "@tauri-apps/plugin-updater": "~2.0.0"
       },
       "devDependencies": {
         "@tauri-apps/cli": "~2.0.0",
@@ -855,9 +857,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -875,9 +874,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -895,9 +891,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -915,9 +908,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -982,6 +972,24 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.0.2.tgz",
       "integrity": "sha512-1bzzaNMSaGT8USiZEoBTxGWCbWpzy0Z8zJlRIDpn1iPxRsS0OGLKucBsZEE6OBY+rB0b2SbPy6/ZyeL04piHLQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.0.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.0.0.tgz",
+      "integrity": "sha512-OYzi0GnkrF4NAnsHZU7U3tjSoP0PbeAlO7T1Z+vJoBUH9sFQ1NSLqWYWQyf8hcb3gVWe7P1JggjiskO+LST1ug==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.0.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.0.0.tgz",
+      "integrity": "sha512-N0cl71g7RPr7zK2Fe5aoIwzw14NcdLcz7XMGFWZVjprsqgDRWoxbnUkknyCQMZthjhGkppCd/wN2MIsUz+eAhQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0"

--- a/mowis-desktop/src-tauri/src/backend.rs
+++ b/mowis-desktop/src-tauri/src/backend.rs
@@ -330,6 +330,12 @@ impl BackendBridge {
         self.state_rx.borrow().connected
     }
 
+    /// Open a fresh connection to agentd independent of the active stream.
+    /// Used by the event subscription task to open a second connection.
+    pub async fn open_fresh_stream(&self) -> Result<crate::platform::connection::ConnectionStream> {
+        self.fresh_stream().await
+    }
+
     /// Retrieve diagnostic logs from the Linux environment.
     pub async fn read_logs(&self) -> String {
         self.launcher.read_logs().await

--- a/mowis-desktop/src-tauri/src/bridge_loop.rs
+++ b/mowis-desktop/src-tauri/src/bridge_loop.rs
@@ -133,6 +133,8 @@ pub fn start_bridge(
     // ── 4. Command handler (background thread with its own tokio runtime) ─────
     let evt_tx_clone = evt_tx.clone();
     let bridge_for_cmds = Arc::clone(&bridge);
+    let state_for_cmds = Arc::clone(&state);
+    let app_for_cmds = app.clone();
     std::thread::Builder::new()
         .name("mowisai-bridge".into())
         .spawn(move || {
@@ -141,6 +143,8 @@ pub fn start_bridge(
                 while let Some(cmd) = cmd_rx.recv().await {
                     let tx = evt_tx_clone.clone();
                     let b = Arc::clone(&bridge_for_cmds);
+                    let st = Arc::clone(&state_for_cmds);
+                    let app_cmd = app_for_cmds.clone();
                     match cmd {
                         BridgeCommand::CheckSocket => {
                             let evt = if b.is_connected() {
@@ -158,8 +162,14 @@ pub fn start_bridge(
                         }
 
                         BridgeCommand::StartOrchestration { session_id, prompt, max_agents, mode, repo_context, config, conversation_history } => {
+                            let b_sub = Arc::clone(&b);
+                            let st_sub = Arc::clone(&st);
+                            let app_sub = app_cmd.clone();
                             tokio::spawn(async move {
                                 run_orchestration(session_id, prompt, max_agents, mode, repo_context, config, b, tx, conversation_history).await;
+                            });
+                            tokio::spawn(async move {
+                                run_event_subscription(b_sub, app_sub, st_sub).await;
                             });
                         }
 
@@ -659,3 +669,88 @@ pub async fn run_orchestration(
 // If you see a simulation running, the binary is STALE — rebuild with:
 //   cd mowis-desktop && cargo tauri build
 // The compiler will error if any code path tries to call simulate_session.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Event subscription (second socket connection for live streaming)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Opens a dedicated socket connection to agentd, subscribes to the event
+/// stream, and re-emits every event as a Tauri "stream_event" event with the
+/// raw JSON payload. Runs until the connection closes or SessionComplete arrives.
+pub async fn run_event_subscription(
+    bridge: Arc<crate::backend::BackendBridge>,
+    app: tauri::AppHandle,
+    state: Arc<crate::state::AppState>,
+) {
+    let mut stream = match bridge.open_fresh_stream().await {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("[bridge] Event subscription: could not open stream: {}", e);
+            return;
+        }
+    };
+
+    let subscribe_msg = serde_json::json!({"request_type": "subscribe_events"});
+    if let Err(e) = stream.send_json(&subscribe_msg).await {
+        log::warn!("[bridge] Event subscription: send subscribe_events failed: {}", e);
+        return;
+    }
+
+    log::info!("[bridge] Event subscription stream active");
+
+    loop {
+        match stream.recv_json().await {
+            Ok(Some(v)) => {
+                let raw = v.to_string();
+                let _ = app.emit("stream_event", &raw);
+
+                let event_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                match event_type {
+                    "AgentStarted" => {
+                        let agent_id = v.get("agent_id")
+                            .and_then(|a| a.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let sandbox = v.get("sandbox")
+                            .and_then(|s| s.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if !agent_id.is_empty() {
+                            state.agent_states.lock().unwrap().insert(agent_id, v.clone());
+                        }
+                        if !sandbox.is_empty() {
+                            let mut ids = state.active_sandbox_ids.lock().unwrap();
+                            if !ids.contains(&sandbox) {
+                                ids.push(sandbox);
+                            }
+                        }
+                    }
+                    "AgentCompleted" | "AgentFailed" => {
+                        let agent_id = v.get("agent_id")
+                            .and_then(|a| a.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        if !agent_id.is_empty() {
+                            state.agent_states.lock().unwrap().insert(agent_id, v.clone());
+                        }
+                    }
+                    "SessionComplete" => {
+                        state.active_sandbox_ids.lock().unwrap().clear();
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(None) => {
+                log::info!("[bridge] Event subscription: stream EOF");
+                break;
+            }
+            Err(e) => {
+                log::warn!("[bridge] Event subscription: stream error: {}", e);
+                break;
+            }
+        }
+    }
+
+    log::info!("[bridge] Event subscription ended");
+}

--- a/mowis-desktop/src-tauri/src/commands.rs
+++ b/mowis-desktop/src-tauri/src/commands.rs
@@ -988,6 +988,19 @@ pub async fn agent_list_messages(
     client.list_messages(&session_id).await.map_err(|e| e.to_string())
 }
 
+/// Return current session streaming state: sandbox IDs, per-agent states, and session ID.
+#[tauri::command]
+pub async fn get_session_state(state: State<'_, Arc<AppState>>) -> Result<serde_json::Value, String> {
+    let session_id = state.current_session_id.lock().unwrap().clone();
+    let sandbox_ids = state.active_sandbox_ids.lock().unwrap().clone();
+    let agent_states = state.agent_states.lock().unwrap().clone();
+    Ok(serde_json::json!({
+        "session_id": session_id,
+        "active_sandbox_ids": sandbox_ids,
+        "agent_states": agent_states,
+    }))
+}
+
 /// Explicitly start (or connect to) the mowis-agent subprocess.
 /// Emits `agent_startup_log` events with `{ text, level }` as it progresses
 /// so the frontend can display live logs in the startup modal.

--- a/mowis-desktop/src-tauri/src/main.rs
+++ b/mowis-desktop/src-tauri/src/main.rs
@@ -79,6 +79,7 @@ fn main() {
             agent_list_messages,
             agent_start,
             open_url,
+            get_session_state,
         ])
         .run(tauri::generate_context!())
         .expect("error running mowis-desktop");

--- a/mowis-desktop/src-tauri/src/state.rs
+++ b/mowis-desktop/src-tauri/src/state.rs
@@ -40,6 +40,11 @@ pub struct AppState {
     pub workspace_path: Mutex<Option<String>>,
     // Changed file paths relative to workspace_path from last WorkspaceReady.
     pub workspace_files: Mutex<Vec<String>>,
+
+    // Sandbox IDs active in the current streaming session.
+    pub active_sandbox_ids: Mutex<Vec<String>>,
+    // Per-agent state keyed by agent_id (populated from subscribe_events stream).
+    pub agent_states: Mutex<HashMap<String, serde_json::Value>>,
 }
 
 impl AppState {
@@ -96,6 +101,8 @@ impl AppState {
             agent_manager: Mutex::new(None),
             workspace_path: Mutex::new(None),
             workspace_files: Mutex::new(Vec::new()),
+            active_sandbox_ids: Mutex::new(Vec::new()),
+            agent_states: Mutex::new(HashMap::new()),
         }
     }
 }

--- a/mowis-desktop/src/bridge.js
+++ b/mowis-desktop/src/bridge.js
@@ -17,6 +17,34 @@ export async function loadTauri() {
     _invoke = invoke;
     _listen = listen;
     _openDialog = open;
+
+    // Bridge: subscribe to stream_event from Rust and fan out as window CustomEvents.
+    // This is the live-streaming pipeline: agentd → Rust → Tauri → JS CustomEvent → chat.js
+    _listen('stream_event', (e) => {
+      let ev;
+      try {
+        ev = typeof e.payload === 'string' ? JSON.parse(e.payload) : e.payload;
+      } catch { return; }
+      const type = ev && (ev.type || ev.event_type || '');
+      if (!type) return;
+      const detail = ev;
+      if (type === 'LlmChunk') {
+        window.dispatchEvent(new CustomEvent('mowis:llm_chunk', { detail }));
+      } else if (type === 'LlmDone') {
+        window.dispatchEvent(new CustomEvent('mowis:llm_done', { detail }));
+      } else if (type === 'ToolCall') {
+        window.dispatchEvent(new CustomEvent('mowis:tool_call', { detail }));
+      } else if (type === 'ToolResult') {
+        window.dispatchEvent(new CustomEvent('mowis:tool_result', { detail }));
+      } else if (type === 'AgentStarted' || type === 'AgentCompleted' || type === 'AgentFailed') {
+        window.dispatchEvent(new CustomEvent('mowis:agent_state', { detail }));
+      } else if (type === 'LayerStarted' || type === 'LayerCompleted') {
+        window.dispatchEvent(new CustomEvent('mowis:layer_progress', { detail }));
+      } else if (type === 'SessionComplete') {
+        window.dispatchEvent(new CustomEvent('mowis:session_complete', { detail }));
+      }
+    }).catch(() => {});
+
     return true;
   } catch { return false; }
 }

--- a/mowis-desktop/src/chat.js
+++ b/mowis-desktop/src/chat.js
@@ -997,6 +997,106 @@ export function renderDiffPanel() {
   detail.innerHTML = `${headerHtml}<div class="diff-panel-body">${linesHtml || '<div class="task-detail-empty">Empty file</div>'}</div>`;
 }
 
+// ── Stream event handlers (mowis: window CustomEvents from bridge.js) ─────────
+// These fire whenever agentd pushes an event through the subscribe_events stream.
+
+window.addEventListener('mowis:llm_chunk', (e) => {
+  const chunk = e.detail?.chunk ?? e.detail?.content ?? e.detail?.text ?? '';
+  if (chunk) appendAgentChunk(chunk);
+});
+
+window.addEventListener('mowis:llm_done', () => {
+  finalizeStreaming();
+});
+
+window.addEventListener('mowis:tool_call', (e) => {
+  const data = e.detail || {};
+  const container = $('chat-messages');
+  if (!container) return;
+  if (State.isStreaming) finalizeStreaming();
+
+  let toolGroup = container.querySelector('.tool-events-group:last-child');
+  if (!toolGroup || toolGroup.dataset.finalized === 'true') {
+    toolGroup = document.createElement('div');
+    toolGroup.className = 'tool-events-group';
+    container.appendChild(toolGroup);
+  }
+
+  const toolName = data.tool_name || data.name || '';
+  const agentId  = data.agent_id  || '';
+  const item = document.createElement('div');
+  item.className = 'tool-event tool-call';
+  item.dataset.toolName = toolName;
+  item.dataset.agentId  = agentId;
+
+  const icon = getToolIcon(toolName);
+  const agentLabel = agentId
+    ? `<span class="tool-agent">${escHtml(agentId.slice(0, 8))}</span>`
+    : '';
+  item.innerHTML = `
+    <span class="tool-icon">${icon}</span>
+    <span class="tool-name">${escHtml(toolName)}</span>
+    ${agentLabel}
+    <span class="tool-spinner"></span>
+  `;
+  toolGroup.appendChild(item);
+  scrollToBottom(container);
+});
+
+window.addEventListener('mowis:tool_result', (e) => {
+  const data = e.detail || {};
+  const container = $('chat-messages');
+  if (!container) return;
+
+  const toolName = data.tool_name || data.name || '';
+  const agentId  = data.agent_id  || '';
+  const success  = data.success !== false;
+  const duration = data.duration_ms != null ? `${data.duration_ms}ms` : '';
+
+  const toolGroup = container.querySelector('.tool-events-group:last-child');
+  if (toolGroup) {
+    const selector = agentId
+      ? `.tool-call[data-tool-name="${toolName}"][data-agent-id="${agentId}"]:not(.resolved)`
+      : `.tool-call[data-tool-name="${toolName}"]:not(.resolved)`;
+    const pending = toolGroup.querySelector(selector);
+    if (pending) {
+      pending.classList.add('resolved', success ? 'success' : 'failed');
+      const spinner = pending.querySelector('.tool-spinner');
+      if (spinner) {
+        spinner.className = success ? 'tool-status-ok' : 'tool-status-fail';
+        spinner.textContent = (success ? '✓' : '✗') + (duration ? ' ' + duration : '');
+      }
+      scrollToBottom(container);
+    }
+  }
+});
+
+window.addEventListener('mowis:agent_state', (e) => {
+  const data = e.detail || {};
+  const type  = data.type || '';
+  if (type === 'AgentStarted') {
+    appendAgentStatusBlock({
+      agent_id: data.agent_id || '',
+      task_id:  data.task_id  || '',
+      sandbox:  data.sandbox  || '',
+    });
+  } else if (type === 'AgentCompleted' || type === 'AgentFailed') {
+    updateAgentStatus({
+      agent_id: data.agent_id || '',
+      status: type === 'AgentCompleted' ? 'complete' : 'failed',
+    });
+  }
+});
+
+window.addEventListener('mowis:layer_progress', () => {
+  // Layer progress events are informational — the Tauri layer_progress event
+  // already handles any visual update needed via main.js
+});
+
+window.addEventListener('mowis:session_complete', () => {
+  finalizeStreaming();
+});
+
 function getFileActionIcon(action) {
   const icons = {
     created: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="12" y1="18" x2="12" y2="12"></line><line x1="9" y1="15" x2="15" y2="15"></line></svg>`,


### PR DESCRIPTION
## Summary

Implements a complete live-streaming event pipeline that connects agentd's event stream to the desktop UI in real-time. Opens a dedicated socket connection to subscribe to agentd events, re-emits them as Tauri events, and dispatches them as window CustomEvents for the chat UI to consume. Enables live visualization of LLM chunks, tool calls/results, agent state transitions, and session progress.

## Key Changes

- **Event subscription task** (`bridge_loop.rs`): Added `run_event_subscription()` that opens a fresh socket connection, subscribes to the `subscribe_events` stream, and re-emits every event as a Tauri `stream_event` with raw JSON payload. Tracks agent states and sandbox IDs in AppState. Spawned as a separate tokio task alongside orchestration.

- **Tauri event bridge** (`bridge.js`): Listens to `stream_event` from Rust and fans out as window CustomEvents (`mowis:llm_chunk`, `mowis:llm_done`, `mowis:tool_call`, `mowis:tool_result`, `mowis:agent_state`, `mowis:layer_progress`, `mowis:session_complete`). Handles both string and object payloads.

- **Chat UI event handlers** (`chat.js`): Added 7 window event listeners that consume the CustomEvents and update the UI:
  - `mowis:llm_chunk` — appends streamed LLM text chunks
  - `mowis:llm_done` — finalizes streaming
  - `mowis:tool_call` — renders tool invocation with spinner
  - `mowis:tool_result` — marks tool as resolved with success/failure status and duration
  - `mowis:agent_state` — handles AgentStarted/Completed/Failed transitions
  - `mowis:layer_progress` — informational (visual updates handled by main.js)
  - `mowis:session_complete` — finalizes streaming and clears state

- **AppState extensions** (`state.rs`): Added `active_sandbox_ids` (Vec<String>) and `agent_states` (HashMap<String, serde_json::Value>) to track live session state populated from the event stream.

- **Backend bridge** (`backend.rs`): Added `open_fresh_stream()` method to open independent socket connections for the event subscription task.

- **Session state query** (`commands.rs`): Added `get_session_state` Tauri command to expose current sandbox IDs, per-agent states, and session ID to the frontend.

- **Command registration** (`main.rs`): Registered `get_session_state` command.

## Implementation Details

- The event subscription runs in a separate tokio task spawned immediately after orchestration starts, ensuring events are captured from the beginning.
- Agent state and sandbox tracking is synchronized via Mutex-protected AppState fields, allowing the frontend to query current state via `get_session_state`.
- Tool result matching uses both tool name and agent ID (when present) to correctly resolve pending tool calls in multi-agent scenarios.
- The pipeline gracefully handles connection errors and stream EOF without crashing the orchestration task.

https://claude.ai/code/session_0167wjbzqPdU6Bp5L1vYzv8Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced real-time event streaming from the backend to the frontend, enabling live updates of agent status transitions and session progress.
  * Added session state visibility with live tracking of active execution environments and agent states.
  * Enhanced the chat interface to display streaming content, tool executions, and completion events as they occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Momin010/MowisAI/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->